### PR TITLE
[FEAT] Lecture 도메인 설계 (#1)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 language: "ko-KR"
 
 reviews:
-  profile: "assertive"
+  profile: "chill"
   request_changes_workflow: true
   high_level_summary: true
   poem: false

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ logs/
 # OS
 .DS_Store
 Thumbs.db
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: goggles-postgres
+    environment:
+      POSTGRES_DB: goggles
+      POSTGRES_USER: goggles
+      POSTGRES_PASSWORD: goggles
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U goggles -d goggles" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7
+    container_name: goggles-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  zipkin:
+    image: openzipkin/zipkin
+    container_name: goggles-zipkin
+    ports:
+      - "9411:9411"
+
+volumes:
+  postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U goggles -d goggles" ]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U goggles -d goggles" ]
+      test: ["CMD-SHELL", "pg_isready -U goggles -d goggles"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -22,7 +22,7 @@ services:
     ports:
       - "6379:6379"
     healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/src/main/java/com/goggles/lecture_service/LectureServiceApplication.java
+++ b/src/main/java/com/goggles/lecture_service/LectureServiceApplication.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import com.goggles.config.event.EventConfig;
 
-//@Import(EventConfig.class)
+
 @SpringBootApplication
 @EnableJpaAuditing
 public class LectureServiceApplication {

--- a/src/main/java/com/goggles/lecture_service/LectureServiceApplication.java
+++ b/src/main/java/com/goggles/lecture_service/LectureServiceApplication.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import com.goggles.config.event.EventConfig;
 
-@Import(EventConfig.class)
+//@Import(EventConfig.class)
 @SpringBootApplication
 @EnableJpaAuditing
 public class LectureServiceApplication {

--- a/src/main/java/com/goggles/lecture_service/LectureServiceApplication.java
+++ b/src/main/java/com/goggles/lecture_service/LectureServiceApplication.java
@@ -1,4 +1,4 @@
-package com.goggles.lecture;
+package com.goggles.lecture_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Chapter.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Chapter.java
@@ -2,6 +2,7 @@ package com.goggles.lecture_service.domain.lecture.entity;
 
 
 import com.goggles.common.domain.BaseAudit;
+import com.goggles.lecture_service.domain.lecture.exception.InvalidSortOrderException;
 import com.goggles.lecture_service.domain.lecture.vo.ChapterContent;
 import com.goggles.lecture_service.domain.lecture.vo.ChapterDuration;
 import jakarta.persistence.Column;
@@ -80,7 +81,7 @@ public class Chapter extends BaseAudit {
 
 	private static void validateSortOrder(int sortOrder) {
 		if (sortOrder < 1) {
-			throw new IllegalArgumentException("챕터 순서는 1 이상이어야 합니다.");
+			throw new InvalidSortOrderException(sortOrder);
 		}
 	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Chapter.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Chapter.java
@@ -1,10 +1,12 @@
 package com.goggles.lecture_service.domain.lecture.entity;
 
+import java.util.UUID;
 
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidSortOrderException;
 import com.goggles.lecture_service.domain.lecture.vo.ChapterContent;
 import com.goggles.lecture_service.domain.lecture.vo.ChapterDuration;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -14,7 +16,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -66,16 +67,16 @@ public class Chapter extends BaseAudit {
 		return lecture.getId();
 	}
 
-	public void updateContent(ChapterContent newContent) {
+	void updateContent(ChapterContent newContent) {
 		this.content = newContent;
 	}
 
-	public void updateSortOrder(int newSortOrder) {
+	void updateSortOrder(int newSortOrder) {
 		validateSortOrder(newSortOrder);
 		this.sortOrder = newSortOrder;
 	}
 
-	public void updateDuration(ChapterDuration newDuration) {
+	void updateDuration(ChapterDuration newDuration) {
 		this.duration = newDuration;
 	}
 

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Chapter.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Chapter.java
@@ -1,0 +1,86 @@
+package com.goggles.lecture_service.domain.lecture.entity;
+
+
+import com.goggles.common.domain.BaseAudit;
+import com.goggles.lecture_service.domain.lecture.vo.ChapterContent;
+import com.goggles.lecture_service.domain.lecture.vo.ChapterDuration;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "p_chapter",
+	uniqueConstraints =
+	@UniqueConstraint(
+		name = "uk_chapter_lecture_sort_order",
+		columnNames = {"lecture_id", "sort_order"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chapter extends BaseAudit {
+
+	@Id
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id = UUID.randomUUID();
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "lecture_id", nullable = false)
+	private Lecture lecture;
+
+	@Embedded
+	private ChapterContent content;
+
+	@Column(nullable = false)
+	private int sortOrder;
+
+	@Embedded
+	private ChapterDuration duration;
+
+	// Lecture.addChapter()를 통해서만 생성 가능 (패키지 접근)
+	static Chapter create(
+		Lecture lecture, ChapterContent content, int sortOrder, ChapterDuration duration) {
+		validateSortOrder(sortOrder);
+		return new Chapter(lecture, content, sortOrder, duration);
+	}
+
+	private Chapter(
+		Lecture lecture, ChapterContent content, int sortOrder, ChapterDuration duration) {
+		this.lecture = lecture;
+		this.content = content;
+		this.sortOrder = sortOrder;
+		this.duration = duration;
+	}
+
+	public UUID getLectureId() {
+		return lecture.getId();
+	}
+
+	public void updateContent(ChapterContent newContent) {
+		this.content = newContent;
+	}
+
+	public void updateSortOrder(int newSortOrder) {
+		validateSortOrder(newSortOrder);
+		this.sortOrder = newSortOrder;
+	}
+
+	public void updateDuration(ChapterDuration newDuration) {
+		this.duration = newDuration;
+	}
+
+	private static void validateSortOrder(int sortOrder) {
+		if (sortOrder < 1) {
+			throw new IllegalArgumentException("챕터 순서는 1 이상이어야 합니다.");
+		}
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
@@ -155,7 +155,7 @@ public class Lecture extends BaseAudit {
 
 		this.content = new LectureContent(title, subtitle, description);
 		this.category = category;
-		this.durationPolicy = durationPolicy;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
 		this.price = Money.of(priceAmount);
 	}
 

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
@@ -1,8 +1,13 @@
 package com.goggles.lecture_service.domain.lecture.entity;
 
 import com.goggles.common.domain.BaseAudit;
+import com.goggles.common.exception.BadRequestException;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import com.goggles.lecture_service.domain.lecture.exception.ChapterNotFoundException;
+import com.goggles.lecture_service.domain.lecture.exception.DuplicateSortOrderException;
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
 import com.goggles.lecture_service.domain.lecture.vo.InstructorInfo;
 import com.goggles.lecture_service.domain.lecture.vo.LectureContent;
 import com.goggles.lecture_service.domain.lecture.vo.Money;
@@ -108,7 +113,7 @@ public class Lecture extends BaseAudit {
 		validateDraftStatus();
 		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
 		if (!removed) {
-			throw new IllegalArgumentException("존재하지 않는 챕터입니다. chapterId=" + chapterId);
+			throw new ChapterNotFoundException(chapterId); // ← 이걸로 교체
 		}
 	}
 
@@ -145,17 +150,17 @@ public class Lecture extends BaseAudit {
 
 	public void submitForReview() {
 		if (this.status != LectureStatus.DRAFT) {
-			throw new IllegalStateException("공개 요청은 DRAFT 상태에서만 가능합니다.");
+			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
 		}
 		if (chapters.isEmpty()) {
-			throw new IllegalStateException("챕터가 최소 1개 이상 있어야 공개 요청이 가능합니다.");
+			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
 		}
 		this.status = LectureStatus.PENDING_REVIEW;
 	}
 
 	public void approve() {
 		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new IllegalStateException("승인은 PENDING_REVIEW 상태에서만 가능합니다.");
+			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
 		}
 		this.status = LectureStatus.PUBLISHED;
 		this.rejectionReason = null;
@@ -163,10 +168,10 @@ public class Lecture extends BaseAudit {
 
 	public void reject(String reason) {
 		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new IllegalStateException("반려는 PENDING_REVIEW 상태에서만 가능합니다.");
+			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
 		}
 		if (reason == null || reason.isBlank()) {
-			throw new IllegalArgumentException("반려 사유는 필수입니다.");
+			throw new BadRequestException("반려 사유는 필수입니다.");
 		}
 		this.status = LectureStatus.DRAFT;
 		this.rejectionReason = reason;
@@ -174,7 +179,7 @@ public class Lecture extends BaseAudit {
 
 	public void hide() {
 		if (this.status != LectureStatus.PUBLISHED) {
-			throw new IllegalStateException("숨김 처리는 PUBLISHED 상태에서만 가능합니다.");
+			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
 		}
 		this.status = LectureStatus.HIDDEN;
 	}
@@ -183,14 +188,14 @@ public class Lecture extends BaseAudit {
 
 	private void validateDraftStatus() {
 		if (this.status != LectureStatus.DRAFT) {
-			throw new IllegalStateException("DRAFT 상태에서만 수정 가능합니다. 현재 상태=" + this.status);
+			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
 		}
 	}
 
 	private void validateDuplicateSortOrder(int sortOrder) {
 		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
 		if (isDuplicate) {
-			throw new IllegalArgumentException("이미 존재하는 챕터 순서입니다. sortOrder=" + sortOrder);
+			throw new DuplicateSortOrderException(sortOrder);
 		}
 	}
 
@@ -198,12 +203,12 @@ public class Lecture extends BaseAudit {
 		return chapters.stream()
 			.filter(c -> c.getId().equals(chapterId))
 			.findFirst()
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 챕터입니다. chapterId=" + chapterId));
+			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
 	}
 
 	private static void validateCategory(String category) {
 		if (category == null || category.isBlank()) {
-			throw new IllegalArgumentException("카테고리는 필수입니다.");
+			throw new BadRequestException("카테고리는 필수입니다.");
 		}
 	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
@@ -1,30 +1,41 @@
 package com.goggles.lecture_service.domain.lecture.entity;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.SQLRestriction;
+
 import com.goggles.common.domain.BaseAudit;
-import com.goggles.common.exception.BadRequestException;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.exception.ChapterNotFoundException;
 import com.goggles.lecture_service.domain.lecture.exception.DuplicateSortOrderException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
-import com.goggles.lecture_service.domain.lecture.vo.InstructorInfo;
-import com.goggles.lecture_service.domain.lecture.vo.LectureContent;
-import com.goggles.lecture_service.domain.lecture.vo.Money;
 import com.goggles.lecture_service.domain.lecture.vo.ChapterContent;
 import com.goggles.lecture_service.domain.lecture.vo.ChapterDuration;
-import jakarta.persistence.*;
+import com.goggles.lecture_service.domain.lecture.vo.Instructor;
+import com.goggles.lecture_service.domain.lecture.vo.LectureContent;
+import com.goggles.lecture_service.domain.lecture.vo.Money;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 @Entity
 @Table(name = "p_lecture")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
@@ -34,7 +45,7 @@ public class Lecture extends BaseAudit {
 	private UUID id = UUID.randomUUID();
 
 	@Embedded
-	private InstructorInfo instructor;
+	private Instructor instructor;
 
 	@Column(nullable = false, length = 50)
 	private String category;
@@ -74,7 +85,7 @@ public class Lecture extends BaseAudit {
 		validateCategory(category);
 
 		return new Lecture(
-			new InstructorInfo(instructorId, instructorName),
+			new Instructor(instructorId, instructorName),
 			category,
 			new LectureContent(title, subtitle, description),
 			durationPolicy,
@@ -83,7 +94,7 @@ public class Lecture extends BaseAudit {
 	}
 
 	private Lecture(
-		InstructorInfo instructor,
+		Instructor instructor,
 		String category,
 		LectureContent content,
 		DurationPolicy durationPolicy,
@@ -120,6 +131,8 @@ public class Lecture extends BaseAudit {
 	public void reorderChapter(UUID chapterId, int newSortOrder) {
 		validateDraftStatus();
 		Chapter target = findChapterById(chapterId);
+		if (target.getSortOrder() == newSortOrder)
+			return;
 		validateDuplicateSortOrder(newSortOrder);
 		target.updateSortOrder(newSortOrder);
 	}
@@ -156,6 +169,8 @@ public class Lecture extends BaseAudit {
 			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
 		}
 		this.status = LectureStatus.PENDING_REVIEW;
+		//리뷰 재신청 시 이전 이유 삭제
+		this.rejectionReason = null;
 	}
 
 	public void approve() {
@@ -171,7 +186,7 @@ public class Lecture extends BaseAudit {
 			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
 		}
 		if (reason == null || reason.isBlank()) {
-			throw new BadRequestException("반려 사유는 필수입니다.");
+			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_REJECTION_REASON_REQUIRED);
 		}
 		this.status = LectureStatus.DRAFT;
 		this.rejectionReason = reason;
@@ -208,7 +223,7 @@ public class Lecture extends BaseAudit {
 
 	private static void validateCategory(String category) {
 		if (category == null || category.isBlank()) {
-			throw new BadRequestException("카테고리는 필수입니다.");
+			throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_CATEGORY_REQUIRED);
 		}
 	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
@@ -1,0 +1,209 @@
+package com.goggles.lecture_service.domain.lecture.entity;
+
+import com.goggles.common.domain.BaseAudit;
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import com.goggles.lecture_service.domain.lecture.vo.InstructorInfo;
+import com.goggles.lecture_service.domain.lecture.vo.LectureContent;
+import com.goggles.lecture_service.domain.lecture.vo.Money;
+import com.goggles.lecture_service.domain.lecture.vo.ChapterContent;
+import com.goggles.lecture_service.domain.lecture.vo.ChapterDuration;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_lecture")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Lecture extends BaseAudit {
+
+	@Id
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id = UUID.randomUUID();
+
+	@Embedded
+	private InstructorInfo instructor;
+
+	@Column(nullable = false, length = 50)
+	private String category;
+
+	@Embedded
+	private LectureContent content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private DurationPolicy durationPolicy;
+
+	@Embedded
+	private Money price;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private LectureStatus status;
+
+	@Column(columnDefinition = "TEXT")
+	private String rejectionReason;
+
+	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Chapter> chapters = new ArrayList<>();
+
+	// ── 정적 팩토리 메서드 ──────────────────────────────────────────────
+
+	public static Lecture create(
+		UUID instructorId,
+		String instructorName,
+		String category,
+		String title,
+		String subtitle,
+		String description,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
+
+		validateCategory(category);
+
+		return new Lecture(
+			new InstructorInfo(instructorId, instructorName),
+			category,
+			new LectureContent(title, subtitle, description),
+			durationPolicy,
+			Money.of(priceAmount)
+		);
+	}
+
+	private Lecture(
+		InstructorInfo instructor,
+		String category,
+		LectureContent content,
+		DurationPolicy durationPolicy,
+		Money price) {
+		this.instructor = instructor;
+		this.category = category;
+		this.content = content;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = price;
+		this.status = LectureStatus.DRAFT;
+	}
+
+	// ── 도메인 메서드 (챕터 관리) ────────────────────────────────────────
+
+	public void addChapter(String title, String content, int sortOrder, int durationSeconds) {
+		validateDraftStatus();
+		validateDuplicateSortOrder(sortOrder);
+
+		// VO 생성을 엔티티 내부에서 처리하여 외부 의존성 감소
+		ChapterContent chapterContent = new ChapterContent(title, content);
+		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+
+		chapters.add(Chapter.create(this, chapterContent, sortOrder, chapterDuration));
+	}
+
+	public void removeChapter(UUID chapterId) {
+		validateDraftStatus();
+		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+		if (!removed) {
+			throw new IllegalArgumentException("존재하지 않는 챕터입니다. chapterId=" + chapterId);
+		}
+	}
+
+	public void reorderChapter(UUID chapterId, int newSortOrder) {
+		validateDraftStatus();
+		Chapter target = findChapterById(chapterId);
+		validateDuplicateSortOrder(newSortOrder);
+		target.updateSortOrder(newSortOrder);
+	}
+
+	public List<Chapter> getChapters() {
+		return Collections.unmodifiableList(chapters);
+	}
+
+	// ── 도메인 메서드 (정보 수정) ──────────────────────────────────
+
+	public void updateMetadata(
+		String title,
+		String subtitle,
+		String description,
+		String category,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
+		validateDraftStatus();
+		validateCategory(category);
+
+		this.content = new LectureContent(title, subtitle, description);
+		this.category = category;
+		this.durationPolicy = durationPolicy;
+		this.price = Money.of(priceAmount);
+	}
+
+	// ── 도메인 메서드 (상태 전이) ────────────────────────────────────────
+
+	public void submitForReview() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new IllegalStateException("공개 요청은 DRAFT 상태에서만 가능합니다.");
+		}
+		if (chapters.isEmpty()) {
+			throw new IllegalStateException("챕터가 최소 1개 이상 있어야 공개 요청이 가능합니다.");
+		}
+		this.status = LectureStatus.PENDING_REVIEW;
+	}
+
+	public void approve() {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new IllegalStateException("승인은 PENDING_REVIEW 상태에서만 가능합니다.");
+		}
+		this.status = LectureStatus.PUBLISHED;
+		this.rejectionReason = null;
+	}
+
+	public void reject(String reason) {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new IllegalStateException("반려는 PENDING_REVIEW 상태에서만 가능합니다.");
+		}
+		if (reason == null || reason.isBlank()) {
+			throw new IllegalArgumentException("반려 사유는 필수입니다.");
+		}
+		this.status = LectureStatus.DRAFT;
+		this.rejectionReason = reason;
+	}
+
+	public void hide() {
+		if (this.status != LectureStatus.PUBLISHED) {
+			throw new IllegalStateException("숨김 처리는 PUBLISHED 상태에서만 가능합니다.");
+		}
+		this.status = LectureStatus.HIDDEN;
+	}
+
+	// ── 내부 검증 및 편의 메서드 ──────────────────────────────────────────────
+
+	private void validateDraftStatus() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new IllegalStateException("DRAFT 상태에서만 수정 가능합니다. 현재 상태=" + this.status);
+		}
+	}
+
+	private void validateDuplicateSortOrder(int sortOrder) {
+		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+		if (isDuplicate) {
+			throw new IllegalArgumentException("이미 존재하는 챕터 순서입니다. sortOrder=" + sortOrder);
+		}
+	}
+
+	private Chapter findChapterById(UUID chapterId) {
+		return chapters.stream()
+			.filter(c -> c.getId().equals(chapterId))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 챕터입니다. chapterId=" + chapterId));
+	}
+
+	private static void validateCategory(String category) {
+		if (category == null || category.isBlank()) {
+			throw new IllegalArgumentException("카테고리는 필수입니다.");
+		}
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/entity/Lecture.java
@@ -96,7 +96,7 @@ public class Lecture extends BaseAudit {
 		this.status = LectureStatus.DRAFT;
 	}
 
-	// ── 도메인 메서드 (챕터 관리) ────────────────────────────────────────
+	// 도메인 메서드 (챕터 관리)
 
 	public void addChapter(String title, String content, int sortOrder, int durationSeconds) {
 		validateDraftStatus();
@@ -128,7 +128,7 @@ public class Lecture extends BaseAudit {
 		return Collections.unmodifiableList(chapters);
 	}
 
-	// ── 도메인 메서드 (정보 수정) ──────────────────────────────────
+	// 도메인 메서드 (정보 수정)
 
 	public void updateMetadata(
 		String title,
@@ -146,7 +146,7 @@ public class Lecture extends BaseAudit {
 		this.price = Money.of(priceAmount);
 	}
 
-	// ── 도메인 메서드 (상태 전이) ────────────────────────────────────────
+	// 도메인 메서드 (상태 전이)
 
 	public void submitForReview() {
 		if (this.status != LectureStatus.DRAFT) {
@@ -184,7 +184,7 @@ public class Lecture extends BaseAudit {
 		this.status = LectureStatus.HIDDEN;
 	}
 
-	// ── 내부 검증 및 편의 메서드 ──────────────────────────────────────────────
+	// 내부 검증 및 편의 메서드
 
 	private void validateDraftStatus() {
 		if (this.status != LectureStatus.DRAFT) {

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/enums/DurationPolicy.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/enums/DurationPolicy.java
@@ -1,0 +1,8 @@
+package com.goggles.lecture_service.domain.lecture.enums;
+
+public enum DurationPolicy {
+	DAYS_90,
+	DAYS_180,
+	DAYS_365,
+	UNLIMITED
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/enums/LectureStatus.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/enums/LectureStatus.java
@@ -1,0 +1,8 @@
+package com.goggles.lecture_service.domain.lecture.enums;
+
+public enum LectureStatus {
+	DRAFT,
+	PENDING_REVIEW,
+	PUBLISHED,
+	HIDDEN
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/ChapterNotFoundException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/ChapterNotFoundException.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.NotFoundException;
+import java.util.UUID;
+
+public class ChapterNotFoundException extends NotFoundException {
+	public ChapterNotFoundException(UUID id) {
+		super(LectureErrorCode.CHAPTER_NOT_FOUND.getMessage() + " id=" + id);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/DuplicateSortOrderException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/DuplicateSortOrderException.java
@@ -1,0 +1,9 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.ConflictException;
+
+public class DuplicateSortOrderException extends ConflictException {
+	public DuplicateSortOrderException(int sortOrder) {
+		super(LectureErrorCode.CHAPTER_DUPLICATE_SORT_ORDER.getMessage() + " sortOrder=" + sortOrder);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidCategoryException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidCategoryException.java
@@ -1,0 +1,9 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InvalidCategoryException extends BadRequestException {
+	public InvalidCategoryException() {
+		super(LectureErrorCode.LECTURE_CATEGORY_REQUIRED.getMessage());
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureStatusException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureStatusException.java
@@ -1,0 +1,9 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InvalidLectureStatusException extends BadRequestException {
+	public InvalidLectureStatusException(LectureErrorCode errorCode) {
+		super(errorCode.getMessage());
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidRejectionReasonException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidRejectionReasonException.java
@@ -1,0 +1,9 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InvalidRejectionReasonException extends BadRequestException {
+	public InvalidRejectionReasonException() {
+		super(LectureErrorCode.LECTURE_REJECTION_REASON_REQUIRED.getMessage());
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidSortOrderException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidSortOrderException.java
@@ -1,0 +1,9 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InvalidSortOrderException extends BadRequestException {
+	public InvalidSortOrderException(int sortOrder) {
+		super(LectureErrorCode.INVALID_SORT_ORDER.getMessage() + " sortOrder=" + sortOrder);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -3,14 +3,16 @@ package com.goggles.lecture_service.domain.lecture.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-`@Getter`
-`@RequiredArgsConstructor`
+@Getter
+@RequiredArgsConstructor
 public enum LectureErrorCode {
 
 	// 강의
 	LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
 	LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
 	LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
+	LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
+	LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
 
 	// 챕터
 	CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -1,24 +1,21 @@
 package com.goggles.lecture_service.domain.lecture.exception;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
+`@Getter`
+`@RequiredArgsConstructor`
 public enum LectureErrorCode {
 
 	// 강의
-	LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-	LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다.", HttpStatus.BAD_REQUEST),
-	LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다.", HttpStatus.BAD_REQUEST),
+	LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
+	LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
+	LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
 
 	// 챕터
-	CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-	CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다.", HttpStatus.CONFLICT),
-	INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다.", HttpStatus.BAD_REQUEST);
+	CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
+	CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
+	INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다.");
 
 	private final String message;
-	private final HttpStatus status;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -1,0 +1,24 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LectureErrorCode {
+
+	// 강의
+	LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+	LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다.", HttpStatus.BAD_REQUEST),
+	LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다.", HttpStatus.BAD_REQUEST),
+
+	// 챕터
+	CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+	CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다.", HttpStatus.CONFLICT),
+	INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다.", HttpStatus.BAD_REQUEST);
+
+	private final String message;
+	private final HttpStatus status;
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureNotFoundException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureNotFoundException.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.NotFoundException;
+import java.util.UUID;
+
+public class LectureNotFoundException extends NotFoundException {
+	public LectureNotFoundException(UUID id) {
+		super(LectureErrorCode.LECTURE_NOT_FOUND.getMessage() + " id=" + id);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
@@ -1,0 +1,21 @@
+package com.goggles.lecture_service.domain.lecture.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.goggles.lecture_service.domain.lecture.entity.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+
+public interface LectureRepository {
+	Lecture save(Lecture lecture);
+
+	Optional<Lecture> findById(UUID id);
+
+	Optional<Lecture> findByIdAndDeletedAtIsNull(UUID id);
+
+	List<Lecture> findAllByInstructorInstructorId(UUID instructorId);
+
+	List<Lecture> findAllByStatus(LectureStatus status);
+
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
@@ -14,7 +14,7 @@ public interface LectureRepository {
 
 	Optional<Lecture> findByIdAndDeletedAtIsNull(UUID id);
 
-	List<Lecture> findAllByInstructorInstructorId(UUID instructorId);
+	List<Lecture> findAllByInstructorId(UUID instructorId);
 
 	List<Lecture> findAllByStatus(LectureStatus status);
 

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
@@ -16,6 +16,5 @@ public interface LectureRepository {
 
 	List<Lecture> findAllByInstructorId(UUID instructorId);
 
-	List<Lecture> findAllByStatus(LectureStatus status);
-
+	List<Lecture> findAllByStatusAndDeletedAtIsNull(LectureStatus status);
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/vo/ChapterContent.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/vo/ChapterContent.java
@@ -1,0 +1,19 @@
+package com.goggles.lecture_service.domain.lecture.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record ChapterContent(
+	@Column(nullable = false, length = 200)
+	String title,
+
+	@Column(columnDefinition = "TEXT")
+	String content
+) {
+	public ChapterContent {
+		if (title == null || title.isBlank()) {
+			throw new IllegalArgumentException("챕터 제목은 필수입니다.");
+		}
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/vo/ChapterDuration.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/vo/ChapterDuration.java
@@ -13,12 +13,4 @@ public record ChapterDuration(
 			throw new IllegalArgumentException("영상 길이는 0 이상이어야 합니다.");
 		}
 	}
-
-	// 필요 시 UI를 위한 편의 메서드 추가 가능
-	public String toFormattedTime() {
-		long h = seconds / 3600;
-		long m = (seconds % 3600) / 60;
-		long s = seconds % 60;
-		return h > 0 ? String.format("%02d:%02d:%02d", h, m, s) : String.format("%02d:%02d", m, s);
-	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/vo/ChapterDuration.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/vo/ChapterDuration.java
@@ -1,0 +1,24 @@
+package com.goggles.lecture_service.domain.lecture.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record ChapterDuration(
+	@Column(name = "duration_seconds", nullable = false)
+	int seconds
+) {
+	public ChapterDuration {
+		if (seconds < 0) {
+			throw new IllegalArgumentException("영상 길이는 0 이상이어야 합니다.");
+		}
+	}
+
+	// 필요 시 UI를 위한 편의 메서드 추가 가능
+	public String toFormattedTime() {
+		long h = seconds / 3600;
+		long m = (seconds % 3600) / 60;
+		long s = seconds % 60;
+		return h > 0 ? String.format("%02d:%02d:%02d", h, m, s) : String.format("%02d:%02d", m, s);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/vo/Instructor.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/vo/Instructor.java
@@ -6,14 +6,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
-public record InstructorInfo(
+public record Instructor(
 	@Column(name = "instructor_id", nullable = false)
 	UUID id,
 	@Column(name = "instructor_name", nullable = false, length = 100)
 	String name
 ) {
-	public InstructorInfo {
-		if (id == null) throw new IllegalArgumentException("강사 ID는 필수입니다.");
-		if (name == null || name.isBlank()) throw new IllegalArgumentException("강사 이름은 필수입니다.");
+	public Instructor {
+		if (id == null)
+			throw new IllegalArgumentException("강사 ID는 필수입니다.");
+		if (name == null || name.isBlank())
+			throw new IllegalArgumentException("강사 이름은 필수입니다.");
 	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/vo/InstructorInfo.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/vo/InstructorInfo.java
@@ -1,0 +1,19 @@
+package com.goggles.lecture_service.domain.lecture.vo;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record InstructorInfo(
+	@Column(name = "instructor_id", nullable = false)
+	UUID id,
+	@Column(name = "instructor_name", nullable = false, length = 100)
+	String name
+) {
+	public InstructorInfo {
+		if (id == null) throw new IllegalArgumentException("강사 ID는 필수입니다.");
+		if (name == null || name.isBlank()) throw new IllegalArgumentException("강사 이름은 필수입니다.");
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/vo/LectureContent.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/vo/LectureContent.java
@@ -1,0 +1,18 @@
+package com.goggles.lecture_service.domain.lecture.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record LectureContent(
+	@Column(nullable = false, length = 200)
+	String title,
+	@Column(length = 300)
+	String subtitle,
+	@Column(columnDefinition = "TEXT")
+	String description
+) {
+	public LectureContent {
+		if (title == null || title.isBlank()) throw new IllegalArgumentException("강의 제목은 필수입니다.");
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/vo/Money.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/vo/Money.java
@@ -1,0 +1,26 @@
+package com.goggles.lecture_service.domain.lecture.vo;
+
+import java.math.BigInteger;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record Money(
+	@Column(name = "price", nullable = false)
+	Long amount
+) {
+	public Money {
+		// Long은 객체이므로 null 체크 후, 기본 연산자로 크기 비교 (오토 언박싱)
+		if (amount == null || amount < 0L) {
+			throw new IllegalArgumentException("가격은 0원 이상이어야 합니다.");
+		}
+	}
+
+	public static Money of(Long amount) {
+		return new Money(amount);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/vo/Money.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/vo/Money.java
@@ -1,12 +1,9 @@
 package com.goggles.lecture_service.domain.lecture.vo;
 
-import java.math.BigInteger;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
 
 @Embeddable
 public record Money(

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
@@ -1,0 +1,19 @@
+package com.goggles.lecture_service.infrastructure.lecture.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goggles.lecture_service.domain.lecture.entity.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+
+public interface LectureJpaRepository extends JpaRepository<Lecture, UUID> {
+
+	Optional<Lecture> findByIdAndDeletedAtIsNull(UUID id);
+
+	List<Lecture> findAllByInstructorInstructorId(UUID instructorId);
+
+	List<Lecture> findAllByStatus(LectureStatus status);
+}

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goggles.lecture_service.domain.lecture.entity.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
@@ -13,7 +15,11 @@ public interface LectureJpaRepository extends JpaRepository<Lecture, UUID> {
 
 	Optional<Lecture> findByIdAndDeletedAtIsNull(UUID id);
 
-	List<Lecture> findAllByInstructorInstructorId(UUID instructorId);
+	@Query(
+		value = "SELECT * FROM lecture.p_lecture WHERE instructor_id = :instructorId AND deleted_at IS NULL",
+		nativeQuery = true
+	)
+	List<Lecture> findAllByInstructorId(@Param("instructorId") UUID instructorId);
 
 	List<Lecture> findAllByStatus(LectureStatus status);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
@@ -15,11 +15,8 @@ public interface LectureJpaRepository extends JpaRepository<Lecture, UUID> {
 
 	Optional<Lecture> findByIdAndDeletedAtIsNull(UUID id);
 
-	@Query(
-		value = "SELECT * FROM lecture.p_lecture WHERE instructor_id = :instructorId AND deleted_at IS NULL",
-		nativeQuery = true
-	)
+	@Query("SELECT l FROM Lecture l WHERE l.instructor.id = :instructorId")
 	List<Lecture> findAllByInstructorId(@Param("instructorId") UUID instructorId);
 
-	List<Lecture> findAllByStatus(LectureStatus status);
+	List<Lecture> findAllByStatusAndDeletedAtIsNull(LectureStatus status);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
@@ -34,8 +34,8 @@ public class LectureRepositoryImpl implements LectureRepository {
 	}
 
 	@Override
-	public List<Lecture> findAllByInstructorInstructorId(UUID instructorId) {
-		return lectureJpaRepository.findAllByInstructorInstructorId(instructorId);
+	public List<Lecture> findAllByInstructorId(UUID instructorId) {
+		return lectureJpaRepository.findAllByInstructorId(instructorId);
 	}
 
 	@Override

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.goggles.lecture_service.infrastructure.lecture.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.goggles.lecture_service.domain.lecture.entity.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureRepositoryImpl implements LectureRepository {
+
+	private final LectureJpaRepository lectureJpaRepository;
+
+	@Override
+	public Lecture save(Lecture lecture) {
+		return lectureJpaRepository.save(lecture);
+	}
+
+	@Override
+	public Optional<Lecture> findById(UUID id) {
+		return lectureJpaRepository.findById(id);
+	}
+
+	@Override
+	public Optional<Lecture> findByIdAndDeletedAtIsNull(UUID id) {
+		return lectureJpaRepository.findByIdAndDeletedAtIsNull(id);
+	}
+
+	@Override
+	public List<Lecture> findAllByInstructorInstructorId(UUID instructorId) {
+		return lectureJpaRepository.findAllByInstructorInstructorId(instructorId);
+	}
+
+	@Override
+	public List<Lecture> findAllByStatus(LectureStatus status) {
+		return lectureJpaRepository.findAllByStatus(status);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
@@ -39,7 +39,8 @@ public class LectureRepositoryImpl implements LectureRepository {
 	}
 
 	@Override
-	public List<Lecture> findAllByStatus(LectureStatus status) {
-		return lectureJpaRepository.findAllByStatus(status);
+
+	public List<Lecture> findAllByStatusAndDeletedAtIsNull(LectureStatus status) {
+		return lectureJpaRepository.findAllByStatusAndDeletedAtIsNull(status);
 	}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: lecture-service
+  config:
+    import: optional:file:.env[.properties]
   datasource:
     url: jdbc:postgresql://localhost:5432/goggles
     username: ${DB_USERNAME:goggles}
@@ -15,6 +17,7 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: false
+    open-in-view: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
@@ -83,11 +86,6 @@ management:
   tracing:
     sampling:
       probability: 0.0
-
-eureka:
-  client:
-    register-with-eureka: false
-    fetch-registry: false
 
 ---
 spring:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,7 +59,7 @@ server:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka/
+      defaultZone: http://${EUREKA_URL1:localhost}:9001/eureka/,http://${EUREKA_URL2:localhost}:9002/eureka/
     register-with-eureka: true
     fetch-registry: true
   instance:

--- a/src/test/java/com/goggles/lecture_service/LectureServiceApplicationTests.java
+++ b/src/test/java/com/goggles/lecture_service/LectureServiceApplicationTests.java
@@ -1,4 +1,4 @@
-package com.goggles.lecture;
+package com.goggles.lecture_service;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
### 📌 관련 이슈
- close #1

### 💡 작업 내용
- Lecture, Chapter 엔티티 설계 및 구현
- LectureStatus, DurationPolicy Enum 정의
- LectureRepository 인터페이스 정의 (도메인 계층)
- LectureRepositoryImpl JPA 구현체 작성 (인프라 계층)
- 도메인 관련 커스텀 예외 클래스 작성

### 🔍 변경 이유
- MSA DDD 설계에 따라 Lecture 도메인 계층 구조 확립
- Lecture 애그리거트 루트 및 Chapter 내부 엔티티 관계 설계
- File Service 분리 설계에 따라 imageKey, videoKey 등 파일 관련 필드 제거

### 📝 리뷰 포인트 (선택)
- Chapter는 Lecture 없이 단독 존재 불가한 내부 엔티티로 설계했으며 독립 Repository 미생성
- DurationPolicy, LectureStatus Enum 상태 전이 방향 확인 부탁드립니다
- 파일 관련 필드를 File Service로 완전 분리한 설계 방향 확인 부탁드립니다

### 🧠 기타 참고 사항
- File Service는 트러블슈팅 기간에 별도 구현 예정
- 로컬 개발 환경 docker-compose 추가 (postgres, redis, zipkin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 강의 작성·수정·삭제 및 상태 전환(초안→심사대기→게시→숨김) 지원
  * 장(Chapter) 추가·제거·재정렬 및 장별 콘텐츠/재생시간 관리
  * 강의 기간 정책(90/180/365일·무제한) 및 가격 설정 기능

* **Chores**
  * Docker Compose 기반 개발 인프라(Postgres, Redis, Zipkin) 추가
  * 애플리케이션 설정 구성 개선(외부 설정 불러오기 등)

* **버그 수정**
  * 개발환경 파일(.env) 무시 규칙 및 기타 .gitignore 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->