### PR TITLE
[FEAT] 챕터 생성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,10 @@ dependencyManagement {
     }
 }
 
+openApi {
+    apiDocsUrl.set("http://localhost:9005/v3/api-docs")
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/http/lecture.http
+++ b/http/lecture.http
@@ -21,9 +21,9 @@ X-User-Name: {{instructorName}}
 > {%
     client.test("강의 생성 성공", function () {
         client.assert(response.status === 201, "응답 코드가 201이어야 합니다.");
-        client.assert(response.body.id !== null, "id가 반환되어야 합니다.");
-        client.assert(response.body.status === "DRAFT", "초기 상태는 DRAFT여야 합니다.");
-        client.global.set("createdLectureId", response.body.id);
+        client.assert(response.body.data.id !== null, "id가 반환되어야 합니다.");
+        client.assert(response.body.data.status === "DRAFT", "초기 상태는 DRAFT여야 합니다.");
+        client.global.set("createdLectureId", response.body.data.id);
     });
 %}
 
@@ -92,3 +92,63 @@ GET http://{{host}}/api/v1/lectures?page=0&size=10
 
 ### 7. 강의 상세 조회 (기존, 위에서 생성한 것 - DRAFT라 404 예상)
 GET http://{{host}}/api/v1/lectures/{{createdLectureId}}
+
+### 8. 챕터 생성 - 성공
+POST http://{{host}}/api/v1/lectures/{{createdLectureId}}/chapters
+Content-Type: application/json
+X-User-Id: {{instructorId}}
+X-User-Name: {{instructorName}}
+
+{
+  "title": "1강. 강의 소개",
+  "content": "스프링 부트 강의 소개 및 학습 목표를 설명합니다.",
+  "sortOrder": 1,
+  "durationSeconds": 600
+}
+
+> {%
+    client.test("챕터 생성 성공", function () {
+        client.assert(response.status === 201, "응답 코드가 201이어야 합니다.");
+        client.assert(response.body.data.lectureId !== null, "lectureId가 반환되어야 합니다.");
+        client.assert(response.body.data.chapterId !== null, "chapterId가 반환되어야 합니다.");
+    });
+%}
+
+### 9. 챕터 생성 - 실패 (존재하지 않는 강의)
+POST http://{{host}}/api/v1/lectures/00000000-0000-0000-0000-000000000000/chapters
+Content-Type: application/json
+X-User-Id: {{instructorId}}
+X-User-Name: {{instructorName}}
+
+{
+  "title": "1강. 강의 소개",
+  "content": "스프링 부트 강의 소개",
+  "sortOrder": 1,
+  "durationSeconds": 600
+}
+
+### 10. 챕터 생성 - 실패 (필수값 누락)
+POST http://{{host}}/api/v1/lectures/{{createdLectureId}}/chapters
+Content-Type: application/json
+X-User-Id: {{instructorId}}
+X-User-Name: {{instructorName}}
+
+{
+  "title": "",
+  "content": "내용",
+  "sortOrder": 1,
+  "durationSeconds": 600
+}
+
+### 11. 챕터 생성 - 실패 (정렬 순서 중복)
+POST http://{{host}}/api/v1/lectures/{{createdLectureId}}/chapters
+Content-Type: application/json
+X-User-Id: {{instructorId}}
+X-User-Name: {{instructorName}}
+
+{
+  "title": "1강. 중복 챕터",
+  "content": "sortOrder가 중복되는 챕터입니다.",
+  "sortOrder": 1,
+  "durationSeconds": 300
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
@@ -2,6 +2,8 @@ package com.goggles.lecture_service.application.lecture;
 
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
@@ -17,4 +19,6 @@ public interface LectureService {
   LectureDetail getLectureDetail(UUID lectureId);
 
   LectureCreateResult createLecture(LectureCreateCommand command);
+
+  ChapterCreateResult createChapter(ChapterCreateCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
@@ -2,6 +2,8 @@ package com.goggles.lecture_service.application.lecture;
 
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 import com.goggles.lecture_service.application.lecture.command.service.LectureCommandService;
@@ -34,5 +36,10 @@ public class LectureServiceImpl implements LectureService {
   @Override
   public LectureCreateResult createLecture(LectureCreateCommand command) {
     return lectureCommandService.createLecture(command);
+  }
+
+  @Override
+  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+    return lectureCommandService.createChapter(command);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateCommand.java
@@ -3,4 +3,4 @@ package com.goggles.lecture_service.application.lecture.command.dto;
 import java.util.UUID;
 
 public record ChapterCreateCommand(
-    UUID lectureId, String title, String content, Integer sortOrder, Integer durationSeconds) {}
+    UUID lectureId, String title, String content, int sortOrder, int durationSeconds) {}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateCommand.java
@@ -1,0 +1,12 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+public record ChapterCreateCommand(
+	UUID lectureId,
+	String title,
+	String content,
+	Integer sortOrder,
+	Integer durationSeconds
+) {
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateCommand.java
@@ -3,10 +3,4 @@ package com.goggles.lecture_service.application.lecture.command.dto;
 import java.util.UUID;
 
 public record ChapterCreateCommand(
-	UUID lectureId,
-	String title,
-	String content,
-	Integer sortOrder,
-	Integer durationSeconds
-) {
-}
+    UUID lectureId, String title, String content, Integer sortOrder, Integer durationSeconds) {}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateResult.java
@@ -1,0 +1,13 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+public record ChapterCreateResult(
+	UUID lectureId,
+	UUID chapterId
+) {
+
+	public static ChapterCreateResult from(UUID lectureId, UUID chapterId) {
+		return new ChapterCreateResult(lectureId, chapterId);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterCreateResult.java
@@ -2,12 +2,9 @@ package com.goggles.lecture_service.application.lecture.command.dto;
 
 import java.util.UUID;
 
-public record ChapterCreateResult(
-	UUID lectureId,
-	UUID chapterId
-) {
+public record ChapterCreateResult(UUID lectureId, UUID chapterId) {
 
-	public static ChapterCreateResult from(UUID lectureId, UUID chapterId) {
-		return new ChapterCreateResult(lectureId, chapterId);
-	}
+  public static ChapterCreateResult from(UUID lectureId, UUID chapterId) {
+    return new ChapterCreateResult(lectureId, chapterId);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
@@ -1,8 +1,12 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 
 public interface LectureCommandService {
-  LectureCreateResult createLecture(LectureCreateCommand command);
+	LectureCreateResult createLecture(LectureCreateCommand command);
+
+	ChapterCreateResult createChapter(ChapterCreateCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
@@ -6,7 +6,7 @@ import com.goggles.lecture_service.application.lecture.command.dto.LectureCreate
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 
 public interface LectureCommandService {
-	LectureCreateResult createLecture(LectureCreateCommand command);
+  LectureCreateResult createLecture(LectureCreateCommand command);
 
-	ChapterCreateResult createChapter(ChapterCreateCommand command);
+  ChapterCreateResult createChapter(ChapterCreateCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -4,10 +4,10 @@ import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreate
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
-import com.goggles.lecture_service.domain.lecture.Chapter;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,10 +45,10 @@ public class LectureCommandServiceImpl implements LectureCommandService {
             .findById(command.lectureId())
             .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    Chapter chapter =
+    UUID chapterId =
         lecture.addChapter(
             command.title(), command.content(), command.sortOrder(), command.durationSeconds());
 
-    return ChapterCreateResult.from(lecture.getId(), chapter.getId());
+    return ChapterCreateResult.from(lecture.getId(), chapterId);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -1,35 +1,60 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
-import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
-import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
-import com.goggles.lecture_service.domain.lecture.Lecture;
-import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
+import com.goggles.lecture_service.domain.lecture.Chapter;
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
+import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LectureCommandServiceImpl implements LectureCommandService {
 
-  private final LectureRepository lectureRepository;
+	private final LectureRepository lectureRepository;
 
-  @Override
-  public LectureCreateResult createLecture(LectureCreateCommand command) {
-    // Todo: APPROVED 상태 강사만 생성 가능 조건 추가
-    Lecture lecture =
-        Lecture.create(
-            command.instructorId(),
-            command.instructorName(),
-            command.category(),
-            command.title(),
-            command.subtitle(),
-            command.description(),
-            command.durationPolicy(),
-            command.price());
+	@Override
+	public LectureCreateResult createLecture(LectureCreateCommand command) {
+		// Todo: APPROVED 상태 강사만 생성 가능 조건 추가
+		Lecture lecture =
+			Lecture.create(
+				command.instructorId(),
+				command.instructorName(),
+				command.category(),
+				command.title(),
+				command.subtitle(),
+				command.description(),
+				command.durationPolicy(),
+				command.price());
 
-    Lecture saved = lectureRepository.save(lecture);
-    return LectureCreateResult.from(saved);
-  }
+		Lecture saved = lectureRepository.save(lecture);
+		return LectureCreateResult.from(saved);
+	}
+
+	@Override
+	@Transactional
+	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+		Lecture lecture = lectureRepository.findById(command.lectureId())
+			.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+
+		Chapter chapter = lecture.addChapter(
+			command.title(),
+			command.content(),
+			command.sortOrder(),
+			command.durationSeconds()
+		);
+
+		lectureRepository.save(lecture);
+
+		return ChapterCreateResult.from(lecture.getId(), chapter.getId());
+	}
+
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -1,8 +1,5 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
@@ -11,50 +8,49 @@ import com.goggles.lecture_service.domain.lecture.Chapter;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LectureCommandServiceImpl implements LectureCommandService {
 
-	private final LectureRepository lectureRepository;
+  private final LectureRepository lectureRepository;
 
-	@Override
-	public LectureCreateResult createLecture(LectureCreateCommand command) {
-		// Todo: APPROVED 상태 강사만 생성 가능 조건 추가
-		Lecture lecture =
-			Lecture.create(
-				command.instructorId(),
-				command.instructorName(),
-				command.category(),
-				command.title(),
-				command.subtitle(),
-				command.description(),
-				command.durationPolicy(),
-				command.price());
+  @Override
+  public LectureCreateResult createLecture(LectureCreateCommand command) {
+    // Todo: APPROVED 상태 강사만 생성 가능 조건 추가
+    Lecture lecture =
+        Lecture.create(
+            command.instructorId(),
+            command.instructorName(),
+            command.category(),
+            command.title(),
+            command.subtitle(),
+            command.description(),
+            command.durationPolicy(),
+            command.price());
 
-		Lecture saved = lectureRepository.save(lecture);
-		return LectureCreateResult.from(saved);
-	}
+    Lecture saved = lectureRepository.save(lecture);
+    return LectureCreateResult.from(saved);
+  }
 
-	@Override
-	@Transactional
-	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-		Lecture lecture = lectureRepository.findById(command.lectureId())
-			.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  @Transactional
+  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		Chapter chapter = lecture.addChapter(
-			command.title(),
-			command.content(),
-			command.sortOrder(),
-			command.durationSeconds()
-		);
+    Chapter chapter =
+        lecture.addChapter(
+            command.title(), command.content(), command.sortOrder(), command.durationSeconds());
 
-		lectureRepository.save(lecture);
+    lectureRepository.save(lecture);
 
-		return ChapterCreateResult.from(lecture.getId(), chapter.getId());
-	}
-
+    return ChapterCreateResult.from(lecture.getId(), chapter.getId());
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -1,8 +1,5 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
@@ -11,46 +8,47 @@ import com.goggles.lecture_service.domain.lecture.Chapter;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LectureCommandServiceImpl implements LectureCommandService {
 
-	private final LectureRepository lectureRepository;
+  private final LectureRepository lectureRepository;
 
-	@Override
-	public LectureCreateResult createLecture(LectureCreateCommand command) {
-		// Todo: APPROVED 상태 강사만 생성 가능 조건 추가
-		Lecture lecture =
-			Lecture.create(
-				command.instructorId(),
-				command.instructorName(),
-				command.category(),
-				command.title(),
-				command.subtitle(),
-				command.description(),
-				command.durationPolicy(),
-				command.price());
+  @Override
+  public LectureCreateResult createLecture(LectureCreateCommand command) {
+    // Todo: APPROVED 상태 강사만 생성 가능 조건 추가
+    Lecture lecture =
+        Lecture.create(
+            command.instructorId(),
+            command.instructorName(),
+            command.category(),
+            command.title(),
+            command.subtitle(),
+            command.description(),
+            command.durationPolicy(),
+            command.price());
 
-		Lecture saved = lectureRepository.save(lecture);
-		return LectureCreateResult.from(saved);
-	}
+    Lecture saved = lectureRepository.save(lecture);
+    return LectureCreateResult.from(saved);
+  }
 
-	@Override
-	@Transactional
-	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  @Transactional
+  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		Chapter chapter =
-			lecture.addChapter(
-				command.title(), command.content(), command.sortOrder(), command.durationSeconds());
+    Chapter chapter =
+        lecture.addChapter(
+            command.title(), command.content(), command.sortOrder(), command.durationSeconds());
 
-		return ChapterCreateResult.from(lecture.getId(), chapter.getId());
-	}
+    return ChapterCreateResult.from(lecture.getId(), chapter.getId());
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -1,5 +1,8 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
@@ -8,49 +11,46 @@ import com.goggles.lecture_service.domain.lecture.Chapter;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LectureCommandServiceImpl implements LectureCommandService {
 
-  private final LectureRepository lectureRepository;
+	private final LectureRepository lectureRepository;
 
-  @Override
-  public LectureCreateResult createLecture(LectureCreateCommand command) {
-    // Todo: APPROVED 상태 강사만 생성 가능 조건 추가
-    Lecture lecture =
-        Lecture.create(
-            command.instructorId(),
-            command.instructorName(),
-            command.category(),
-            command.title(),
-            command.subtitle(),
-            command.description(),
-            command.durationPolicy(),
-            command.price());
+	@Override
+	public LectureCreateResult createLecture(LectureCreateCommand command) {
+		// Todo: APPROVED 상태 강사만 생성 가능 조건 추가
+		Lecture lecture =
+			Lecture.create(
+				command.instructorId(),
+				command.instructorName(),
+				command.category(),
+				command.title(),
+				command.subtitle(),
+				command.description(),
+				command.durationPolicy(),
+				command.price());
 
-    Lecture saved = lectureRepository.save(lecture);
-    return LectureCreateResult.from(saved);
-  }
+		Lecture saved = lectureRepository.save(lecture);
+		return LectureCreateResult.from(saved);
+	}
 
-  @Override
-  @Transactional
-  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-    Lecture lecture =
-        lectureRepository
-            .findById(command.lectureId())
-            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+	@Override
+	@Transactional
+	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    Chapter chapter =
-        lecture.addChapter(
-            command.title(), command.content(), command.sortOrder(), command.durationSeconds());
+		Chapter chapter =
+			lecture.addChapter(
+				command.title(), command.content(), command.sortOrder(), command.durationSeconds());
 
-    lectureRepository.save(lecture);
-
-    return ChapterCreateResult.from(lecture.getId(), chapter.getId());
-  }
+		return ChapterCreateResult.from(lecture.getId(), chapter.getId());
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Chapter.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Chapter.java
@@ -11,7 +11,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -52,10 +51,10 @@ public class Chapter extends BaseAudit {
 
   private Chapter(
       Lecture lecture, ChapterContent content, int sortOrder, ChapterDuration duration) {
-    this.lecture = Objects.requireNonNull(lecture, "lecture는 필수입니다.");
-    this.content = Objects.requireNonNull(content, "content는 필수입니다.");
+    this.lecture = lecture;
+    this.content = content;
     this.sortOrder = sortOrder;
-    this.duration = Objects.requireNonNull(duration, "duration은 필수입니다.");
+    this.duration = duration;
   }
 
   public UUID getLectureId() {
@@ -63,7 +62,7 @@ public class Chapter extends BaseAudit {
   }
 
   void updateContent(ChapterContent newContent) {
-    this.content = Objects.requireNonNull(newContent, "content는 필수입니다.");
+    this.content = newContent;
   }
 
   void updateSortOrder(int newSortOrder) {
@@ -72,7 +71,7 @@ public class Chapter extends BaseAudit {
   }
 
   void updateDuration(ChapterDuration newDuration) {
-    this.duration = Objects.requireNonNull(newDuration, "duration은 필수입니다.");
+    this.duration = newDuration;
   }
 
   private static void validateSortOrder(int sortOrder) {

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Chapter.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Chapter.java
@@ -1,7 +1,9 @@
 package com.goggles.lecture_service.domain.lecture;
 
 import com.goggles.common.domain.BaseAudit;
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidSortOrderException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -51,6 +53,12 @@ public class Chapter extends BaseAudit {
 
   private Chapter(
       Lecture lecture, ChapterContent content, int sortOrder, ChapterDuration duration) {
+    if (lecture == null)
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_LECTURE_REQUIRED);
+    if (content == null)
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_CONTENT_REQUIRED);
+    if (duration == null)
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_DURATION_REQUIRED);
     this.lecture = lecture;
     this.content = content;
     this.sortOrder = sortOrder;
@@ -62,6 +70,8 @@ public class Chapter extends BaseAudit {
   }
 
   void updateContent(ChapterContent newContent) {
+    if (newContent == null)
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_CONTENT_REQUIRED);
     this.content = newContent;
   }
 
@@ -71,6 +81,8 @@ public class Chapter extends BaseAudit {
   }
 
   void updateDuration(ChapterDuration newDuration) {
+    if (newDuration == null)
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_DURATION_REQUIRED);
     this.duration = newDuration;
   }
 

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterContent.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterContent.java
@@ -1,9 +1,13 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class ChapterContent {
 
   @Column(nullable = false, length = 200)
@@ -15,17 +19,11 @@ public class ChapterContent {
   protected ChapterContent() {}
 
   public ChapterContent(String title, String content) {
-    if (title == null || title.isBlank()) throw new IllegalArgumentException("챕터 제목은 필수입니다.");
-    if (title.length() > 200) throw new IllegalArgumentException("챕터 제목은 200자 이하여야 합니다.");
+    if (title == null || title.isBlank())
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_TITLE_REQUIRED);
+    if (title.length() > 200)
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_TITLE_TOO_LONG);
     this.title = title;
     this.content = content;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public String getContent() {
-    return content;
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterDuration.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterDuration.java
@@ -16,8 +16,8 @@ public class ChapterDuration {
   protected ChapterDuration() {}
 
   public ChapterDuration(int seconds) {
-    if (seconds < 0)
-      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_DURATION_NEGATIVE);
+    if (seconds < 1)
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_DURATION_INVALID);
     this.seconds = seconds;
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterDuration.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterDuration.java
@@ -6,17 +6,19 @@ import jakarta.persistence.Embeddable;
 @Embeddable
 public class ChapterDuration {
 
-  @Column(name = "duration_seconds", nullable = false)
-  private int seconds;
+	@Column(name = "duration_seconds", nullable = false)
+	private int seconds;
 
-  protected ChapterDuration() {}
+	protected ChapterDuration() {
+	}
 
-  public ChapterDuration(int seconds) {
-    if (seconds < 0) throw new IllegalArgumentException("영상 길이는 0 이상이어야 합니다.");
-    this.seconds = seconds;
-  }
+	public ChapterDuration(int seconds) {
+		if (seconds < 1)
+			throw new IllegalArgumentException("영상 길이는 1 이상이어야 합니다.");
+		this.seconds = seconds;
+	}
 
-  public int getSeconds() {
-    return seconds;
-  }
+	public int getSeconds() {
+		return seconds;
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterDuration.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterDuration.java
@@ -1,24 +1,23 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class ChapterDuration {
 
-	@Column(name = "duration_seconds", nullable = false)
-	private int seconds;
+  @Column(name = "duration_seconds", nullable = false)
+  private int seconds;
 
-	protected ChapterDuration() {
-	}
+  protected ChapterDuration() {}
 
-	public ChapterDuration(int seconds) {
-		if (seconds < 1)
-			throw new IllegalArgumentException("영상 길이는 1 이상이어야 합니다.");
-		this.seconds = seconds;
-	}
-
-	public int getSeconds() {
-		return seconds;
-	}
+  public ChapterDuration(int seconds) {
+    if (seconds < 0)
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_DURATION_NEGATIVE);
+    this.seconds = seconds;
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Instructor.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Instructor.java
@@ -1,10 +1,14 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.UUID;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class Instructor {
 
   @Column(name = "instructor_id", nullable = false)
@@ -16,19 +20,13 @@ public class Instructor {
   protected Instructor() {}
 
   public Instructor(UUID instructorId, String instructorName) {
-    if (instructorId == null) throw new IllegalArgumentException("강사 ID는 필수입니다.");
+    if (instructorId == null)
+      throw new InvalidLectureFieldException(LectureErrorCode.INSTRUCTOR_ID_REQUIRED);
     if (instructorName == null || instructorName.isBlank())
-      throw new IllegalArgumentException("강사 이름은 필수입니다.");
-    if (instructorName.length() > 100) throw new IllegalArgumentException("강사 이름은 100자 이하여야 합니다.");
+      throw new InvalidLectureFieldException(LectureErrorCode.INSTRUCTOR_NAME_REQUIRED);
+    if (instructorName.length() > 100)
+      throw new InvalidLectureFieldException(LectureErrorCode.INSTRUCTOR_NAME_TOO_LONG);
     this.instructorId = instructorId;
     this.instructorName = instructorName;
-  }
-
-  public UUID getInstructorId() {
-    return instructorId;
-  }
-
-  public String getInstructorName() {
-    return instructorName;
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -100,7 +100,7 @@ public class Lecture extends BaseAudit {
 
   // 도메인 메서드 (챕터 관리)
 
-  public Chapter addChapter(String title, String content, int sortOrder, int durationSeconds) {
+  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
     validateDraftStatus();
     validateDuplicateSortOrder(sortOrder);
 
@@ -110,7 +110,7 @@ public class Lecture extends BaseAudit {
     Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
     chapters.add(chapter);
 
-    return chapter;
+    return chapter.getId();
   }
 
   public void removeChapter(UUID chapterId) {

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,12 +1,5 @@
 package com.goggles.lecture_service.domain.lecture;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import org.hibernate.annotations.SQLRestriction;
-
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
@@ -15,7 +8,6 @@ import com.goggles.lecture_service.domain.lecture.exception.DuplicateSortOrderEx
 import com.goggles.lecture_service.domain.lecture.exception.InvalidCategoryException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -25,9 +17,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -36,191 +33,187 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-	@Id
-	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
-	private UUID id = UUID.randomUUID();
+  @Id
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id = UUID.randomUUID();
 
-	@Embedded
-	private Instructor instructor;
+  @Embedded private Instructor instructor;
 
-	@Column(nullable = false, length = 50)
-	private String category;
+  @Column(nullable = false, length = 50)
+  private String category;
 
-	@Embedded
-	private LectureContent content;
+  @Embedded private LectureContent content;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private DurationPolicy durationPolicy;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private DurationPolicy durationPolicy;
 
-	@Embedded
-	private Money price;
+  @Embedded private Money price;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private LectureStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private LectureStatus status;
 
-	@Column(columnDefinition = "TEXT")
-	private String rejectionReason;
+  @Column(columnDefinition = "TEXT")
+  private String rejectionReason;
 
-	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Chapter> chapters = new ArrayList<>();
+  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Chapter> chapters = new ArrayList<>();
 
-	// 정적 팩토리 메서드
+  // 정적 팩토리 메서드
 
-	public static Lecture create(
-		UUID instructorId,
-		String instructorName,
-		String category,
-		String title,
-		String subtitle,
-		String description,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
+  public static Lecture create(
+      UUID instructorId,
+      String instructorName,
+      String category,
+      String title,
+      String subtitle,
+      String description,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
 
-		validateCategory(category);
+    validateCategory(category);
 
-		return new Lecture(
-			new Instructor(instructorId, instructorName),
-			category,
-			new LectureContent(title, subtitle, description),
-			durationPolicy,
-			Money.of(priceAmount));
-	}
+    return new Lecture(
+        new Instructor(instructorId, instructorName),
+        category,
+        new LectureContent(title, subtitle, description),
+        durationPolicy,
+        Money.of(priceAmount));
+  }
 
-	private Lecture(
-		Instructor instructor,
-		String category,
-		LectureContent content,
-		DurationPolicy durationPolicy,
-		Money price) {
-		this.instructor = instructor;
-		this.category = category;
-		this.content = content;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = price;
-		this.status = LectureStatus.DRAFT;
-	}
+  private Lecture(
+      Instructor instructor,
+      String category,
+      LectureContent content,
+      DurationPolicy durationPolicy,
+      Money price) {
+    this.instructor = instructor;
+    this.category = category;
+    this.content = content;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = price;
+    this.status = LectureStatus.DRAFT;
+  }
 
-	// 도메인 메서드 (챕터 관리)
+  // 도메인 메서드 (챕터 관리)
 
-	public Chapter addChapter(String title, String content, int sortOrder, int durationSeconds) {
-		validateDraftStatus();
-		validateDuplicateSortOrder(sortOrder);
+  public Chapter addChapter(String title, String content, int sortOrder, int durationSeconds) {
+    validateDraftStatus();
+    validateDuplicateSortOrder(sortOrder);
 
-		ChapterContent chapterContent = new ChapterContent(title, content);
-		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+    ChapterContent chapterContent = new ChapterContent(title, content);
+    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-		chapters.add(chapter);
+    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+    chapters.add(chapter);
 
-		return chapter;
-	}
+    return chapter;
+  }
 
-	public void removeChapter(UUID chapterId) {
-		validateDraftStatus();
-		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-		if (!removed) {
-			throw new ChapterNotFoundException(chapterId);
-		}
-	}
+  public void removeChapter(UUID chapterId) {
+    validateDraftStatus();
+    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+    if (!removed) {
+      throw new ChapterNotFoundException(chapterId);
+    }
+  }
 
-	public void reorderChapter(UUID chapterId, int newSortOrder) {
-		validateDraftStatus();
-		Chapter target = findChapterById(chapterId);
-		if (target.getSortOrder() == newSortOrder)
-			return;
-		validateDuplicateSortOrder(newSortOrder);
-		target.updateSortOrder(newSortOrder);
-	}
+  public void reorderChapter(UUID chapterId, int newSortOrder) {
+    validateDraftStatus();
+    Chapter target = findChapterById(chapterId);
+    if (target.getSortOrder() == newSortOrder) return;
+    validateDuplicateSortOrder(newSortOrder);
+    target.updateSortOrder(newSortOrder);
+  }
 
-	public List<Chapter> getChapters() {
-		return Collections.unmodifiableList(chapters);
-	}
+  public List<Chapter> getChapters() {
+    return Collections.unmodifiableList(chapters);
+  }
 
-	// 도메인 메서드 (정보 수정)
+  // 도메인 메서드 (정보 수정)
 
-	public void updateMetadata(
-		String title,
-		String subtitle,
-		String description,
-		String category,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
-		validateDraftStatus();
-		validateCategory(category);
+  public void updateMetadata(
+      String title,
+      String subtitle,
+      String description,
+      String category,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
+    validateDraftStatus();
+    validateCategory(category);
 
-		this.content = new LectureContent(title, subtitle, description);
-		this.category = category;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = Money.of(priceAmount);
-	}
+    this.content = new LectureContent(title, subtitle, description);
+    this.category = category;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = Money.of(priceAmount);
+  }
 
-	// 도메인 메서드 (상태 전이)
+  // 도메인 메서드 (상태 전이)
 
-	public void submitForReview() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (chapters.isEmpty()) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.PENDING_REVIEW;
-		// 리뷰 재신청 시 이전 이유 삭제
-		this.rejectionReason = null;
-	}
+  public void submitForReview() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (chapters.isEmpty()) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.PENDING_REVIEW;
+    // 리뷰 재신청 시 이전 이유 삭제
+    this.rejectionReason = null;
+  }
 
-	public void approve() {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.PUBLISHED;
-		this.rejectionReason = null;
-	}
+  public void approve() {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.PUBLISHED;
+    this.rejectionReason = null;
+  }
 
-	public void reject(String reason) {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (reason == null || reason.isBlank()) {
-			throw new InvalidRejectionReasonException();
-		}
-		this.status = LectureStatus.DRAFT;
-		this.rejectionReason = reason;
-	}
+  public void reject(String reason) {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new InvalidRejectionReasonException();
+    }
+    this.status = LectureStatus.DRAFT;
+    this.rejectionReason = reason;
+  }
 
-	public void hide() {
-		if (this.status != LectureStatus.PUBLISHED) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.HIDDEN;
-	}
+  public void hide() {
+    if (this.status != LectureStatus.PUBLISHED) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.HIDDEN;
+  }
 
-	// 내부 검증 및 편의 메서드
+  // 내부 검증 및 편의 메서드
 
-	private void validateDraftStatus() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-	}
+  private void validateDraftStatus() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+  }
 
-	private void validateDuplicateSortOrder(int sortOrder) {
-		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-		if (isDuplicate) {
-			throw new DuplicateSortOrderException(sortOrder);
-		}
-	}
+  private void validateDuplicateSortOrder(int sortOrder) {
+    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+    if (isDuplicate) {
+      throw new DuplicateSortOrderException(sortOrder);
+    }
+  }
 
-	private Chapter findChapterById(UUID chapterId) {
-		return chapters.stream()
-			.filter(c -> c.getId().equals(chapterId))
-			.findFirst()
-			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
-	}
+  private Chapter findChapterById(UUID chapterId) {
+    return chapters.stream()
+        .filter(c -> c.getId().equals(chapterId))
+        .findFirst()
+        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
+  }
 
-	private static void validateCategory(String category) {
-		if (category == null || category.isBlank()) {
-			throw new InvalidCategoryException();
-		}
-	}
+  private static void validateCategory(String category) {
+    if (category == null || category.isBlank()) {
+      throw new InvalidCategoryException();
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -6,8 +6,10 @@ import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.exception.ChapterNotFoundException;
 import com.goggles.lecture_service.domain.lecture.exception.DuplicateSortOrderException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidCategoryException;
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -156,7 +158,7 @@ public class Lecture extends BaseAudit {
       throw new InvalidLectureStatusException(id, status);
     }
     if (chapters.isEmpty()) {
-      throw new InvalidLectureStatusException(id, status);
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
     }
     this.status = LectureStatus.PENDING_REVIEW;
     // 리뷰 재신청 시 이전 이유 삭제

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,5 +1,12 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.SQLRestriction;
+
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
@@ -8,7 +15,7 @@ import com.goggles.lecture_service.domain.lecture.exception.DuplicateSortOrderEx
 import com.goggles.lecture_service.domain.lecture.exception.InvalidCategoryException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
-import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -18,14 +25,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -34,185 +36,191 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-  @Id
-  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
-  private UUID id = UUID.randomUUID();
+	@Id
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id = UUID.randomUUID();
 
-  @Embedded private Instructor instructor;
+	@Embedded
+	private Instructor instructor;
 
-  @Column(nullable = false, length = 50)
-  private String category;
+	@Column(nullable = false, length = 50)
+	private String category;
 
-  @Embedded private LectureContent content;
+	@Embedded
+	private LectureContent content;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private DurationPolicy durationPolicy;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private DurationPolicy durationPolicy;
 
-  @Embedded private Money price;
+	@Embedded
+	private Money price;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private LectureStatus status;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private LectureStatus status;
 
-  @Column(columnDefinition = "TEXT")
-  private String rejectionReason;
+	@Column(columnDefinition = "TEXT")
+	private String rejectionReason;
 
-  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Chapter> chapters = new ArrayList<>();
+	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Chapter> chapters = new ArrayList<>();
 
-  // 정적 팩토리 메서드
+	// 정적 팩토리 메서드
 
-  public static Lecture create(
-      UUID instructorId,
-      String instructorName,
-      String category,
-      String title,
-      String subtitle,
-      String description,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
+	public static Lecture create(
+		UUID instructorId,
+		String instructorName,
+		String category,
+		String title,
+		String subtitle,
+		String description,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
 
-    validateCategory(category);
+		validateCategory(category);
 
-    return new Lecture(
-        new Instructor(instructorId, instructorName),
-        category,
-        new LectureContent(title, subtitle, description),
-        durationPolicy,
-        Money.of(priceAmount));
-  }
+		return new Lecture(
+			new Instructor(instructorId, instructorName),
+			category,
+			new LectureContent(title, subtitle, description),
+			durationPolicy,
+			Money.of(priceAmount));
+	}
 
-  private Lecture(
-      Instructor instructor,
-      String category,
-      LectureContent content,
-      DurationPolicy durationPolicy,
-      Money price) {
-    this.instructor = instructor;
-    this.category = category;
-    this.content = content;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = price;
-    this.status = LectureStatus.DRAFT;
-  }
+	private Lecture(
+		Instructor instructor,
+		String category,
+		LectureContent content,
+		DurationPolicy durationPolicy,
+		Money price) {
+		this.instructor = instructor;
+		this.category = category;
+		this.content = content;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = price;
+		this.status = LectureStatus.DRAFT;
+	}
 
-  // 도메인 메서드 (챕터 관리)
+	// 도메인 메서드 (챕터 관리)
 
-  public void addChapter(String title, String content, int sortOrder, int durationSeconds) {
-    validateDraftStatus();
-    validateDuplicateSortOrder(sortOrder);
+	public Chapter addChapter(String title, String content, int sortOrder, int durationSeconds) {
+		validateDraftStatus();
+		validateDuplicateSortOrder(sortOrder);
 
-    // VO 생성을 엔티티 내부에서 처리하여 외부 의존성 감소
-    ChapterContent chapterContent = new ChapterContent(title, content);
-    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+		ChapterContent chapterContent = new ChapterContent(title, content);
+		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-    chapters.add(Chapter.create(this, chapterContent, sortOrder, chapterDuration));
-  }
+		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+		chapters.add(chapter);
 
-  public void removeChapter(UUID chapterId) {
-    validateDraftStatus();
-    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-    if (!removed) {
-      throw new ChapterNotFoundException(chapterId);
-    }
-  }
+		return chapter;
+	}
 
-  public void reorderChapter(UUID chapterId, int newSortOrder) {
-    validateDraftStatus();
-    Chapter target = findChapterById(chapterId);
-    if (target.getSortOrder() == newSortOrder) return;
-    validateDuplicateSortOrder(newSortOrder);
-    target.updateSortOrder(newSortOrder);
-  }
+	public void removeChapter(UUID chapterId) {
+		validateDraftStatus();
+		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+		if (!removed) {
+			throw new ChapterNotFoundException(chapterId);
+		}
+	}
 
-  public List<Chapter> getChapters() {
-    return Collections.unmodifiableList(chapters);
-  }
+	public void reorderChapter(UUID chapterId, int newSortOrder) {
+		validateDraftStatus();
+		Chapter target = findChapterById(chapterId);
+		if (target.getSortOrder() == newSortOrder)
+			return;
+		validateDuplicateSortOrder(newSortOrder);
+		target.updateSortOrder(newSortOrder);
+	}
 
-  // 도메인 메서드 (정보 수정)
+	public List<Chapter> getChapters() {
+		return Collections.unmodifiableList(chapters);
+	}
 
-  public void updateMetadata(
-      String title,
-      String subtitle,
-      String description,
-      String category,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
-    validateDraftStatus();
-    validateCategory(category);
+	// 도메인 메서드 (정보 수정)
 
-    this.content = new LectureContent(title, subtitle, description);
-    this.category = category;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = Money.of(priceAmount);
-  }
+	public void updateMetadata(
+		String title,
+		String subtitle,
+		String description,
+		String category,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
+		validateDraftStatus();
+		validateCategory(category);
 
-  // 도메인 메서드 (상태 전이)
+		this.content = new LectureContent(title, subtitle, description);
+		this.category = category;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = Money.of(priceAmount);
+	}
 
-  public void submitForReview() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
-    }
-    if (chapters.isEmpty()) {
-      throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-    }
-    this.status = LectureStatus.PENDING_REVIEW;
-    // 리뷰 재신청 시 이전 이유 삭제
-    this.rejectionReason = null;
-  }
+	// 도메인 메서드 (상태 전이)
 
-  public void approve() {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
-    }
-    this.status = LectureStatus.PUBLISHED;
-    this.rejectionReason = null;
-  }
+	public void submitForReview() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (chapters.isEmpty()) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.PENDING_REVIEW;
+		// 리뷰 재신청 시 이전 이유 삭제
+		this.rejectionReason = null;
+	}
 
-  public void reject(String reason) {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
-    }
-    if (reason == null || reason.isBlank()) {
-      throw new InvalidRejectionReasonException();
-    }
-    this.status = LectureStatus.DRAFT;
-    this.rejectionReason = reason;
-  }
+	public void approve() {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.PUBLISHED;
+		this.rejectionReason = null;
+	}
 
-  public void hide() {
-    if (this.status != LectureStatus.PUBLISHED) {
-      throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
-    }
-    this.status = LectureStatus.HIDDEN;
-  }
+	public void reject(String reason) {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (reason == null || reason.isBlank()) {
+			throw new InvalidRejectionReasonException();
+		}
+		this.status = LectureStatus.DRAFT;
+		this.rejectionReason = reason;
+	}
 
-  // 내부 검증 및 편의 메서드
+	public void hide() {
+		if (this.status != LectureStatus.PUBLISHED) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.HIDDEN;
+	}
 
-  private void validateDraftStatus() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(LectureErrorCode.LECTURE_INVALID_STATUS);
-    }
-  }
+	// 내부 검증 및 편의 메서드
 
-  private void validateDuplicateSortOrder(int sortOrder) {
-    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-    if (isDuplicate) {
-      throw new DuplicateSortOrderException(sortOrder);
-    }
-  }
+	private void validateDraftStatus() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+	}
 
-  private Chapter findChapterById(UUID chapterId) {
-    return chapters.stream()
-        .filter(c -> c.getId().equals(chapterId))
-        .findFirst()
-        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
-  }
+	private void validateDuplicateSortOrder(int sortOrder) {
+		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+		if (isDuplicate) {
+			throw new DuplicateSortOrderException(sortOrder);
+		}
+	}
 
-  private static void validateCategory(String category) {
-    if (category == null || category.isBlank()) {
-      throw new InvalidCategoryException();
-    }
-  }
+	private Chapter findChapterById(UUID chapterId) {
+		return chapters.stream()
+			.filter(c -> c.getId().equals(chapterId))
+			.findFirst()
+			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
+	}
+
+	private static void validateCategory(String category) {
+		if (category == null || category.isBlank()) {
+			throw new InvalidCategoryException();
+		}
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/LectureContent.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/LectureContent.java
@@ -1,9 +1,13 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class LectureContent {
 
   @Column(nullable = false, length = 200)
@@ -18,24 +22,14 @@ public class LectureContent {
   protected LectureContent() {}
 
   public LectureContent(String title, String subtitle, String description) {
-    if (title == null || title.isBlank()) throw new IllegalArgumentException("강의 제목은 필수입니다.");
-    if (title.length() > 200) throw new IllegalArgumentException("강의 제목은 200자 이하여야 합니다.");
+    if (title == null || title.isBlank())
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_TITLE_REQUIRED);
+    if (title.length() > 200)
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_TITLE_TOO_LONG);
     if (subtitle != null && subtitle.length() > 300)
-      throw new IllegalArgumentException("강의 부제목은 300자 이하여야 합니다.");
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_SUBTITLE_TOO_LONG);
     this.title = title;
     this.subtitle = subtitle;
     this.description = description;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public String getSubtitle() {
-    return subtitle;
-  }
-
-  public String getDescription() {
-    return description;
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Money.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Money.java
@@ -1,9 +1,13 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class Money {
 
   @Column(name = "price", nullable = false)
@@ -11,18 +15,15 @@ public class Money {
 
   protected Money() {}
 
+  // Money.java
   private Money(Long amount) {
     if (amount == null || amount < 0L) {
-      throw new IllegalArgumentException("가격은 0원 이상이어야 합니다.");
+      throw new InvalidLectureFieldException(LectureErrorCode.PRICE_NEGATIVE);
     }
     this.amount = amount;
   }
 
   public static Money of(Long amount) {
     return new Money(amount);
-  }
-
-  public Long getAmount() {
-    return amount;
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Money.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Money.java
@@ -15,7 +15,6 @@ public class Money {
 
   protected Money() {}
 
-  // Money.java
   private Money(Long amount) {
     if (amount == null || amount < 0L) {
       throw new InvalidLectureFieldException(LectureErrorCode.PRICE_NEGATIVE);

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureFieldException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureFieldException.java
@@ -1,0 +1,9 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InvalidLectureFieldException extends BadRequestException {
+  public InvalidLectureFieldException(LectureErrorCode errorCode) {
+    super(errorCode.getMessage());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureStatusException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureStatusException.java
@@ -1,9 +1,13 @@
 package com.goggles.lecture_service.domain.lecture.exception;
 
+import java.util.UUID;
+
 import com.goggles.common.exception.BadRequestException;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 
 public class InvalidLectureStatusException extends BadRequestException {
-  public InvalidLectureStatusException(LectureErrorCode errorCode) {
-    super(errorCode.getMessage());
-  }
+
+	public InvalidLectureStatusException(UUID lectureId, LectureStatus status) {
+		super("수정 가능한 강의 상태가 아닙니다. lectureId=" + lectureId + ", status=" + status);
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureStatusException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureStatusException.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 public class InvalidLectureStatusException extends BadRequestException {
 
   public InvalidLectureStatusException(UUID lectureId, LectureStatus status) {
-    super("수정 가능한 강의 상태가 아닙니다. lectureId=" + lectureId + ", status=" + status);
+    super("요청한 작업을 수행할 수 없는 강의 상태입니다. lectureId=" + lectureId + ", status=" + status);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureStatusException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidLectureStatusException.java
@@ -1,13 +1,12 @@
 package com.goggles.lecture_service.domain.lecture.exception;
 
-import java.util.UUID;
-
 import com.goggles.common.exception.BadRequestException;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import java.util.UUID;
 
 public class InvalidLectureStatusException extends BadRequestException {
 
-	public InvalidLectureStatusException(UUID lectureId, LectureStatus status) {
-		super("수정 가능한 강의 상태가 아닙니다. lectureId=" + lectureId + ", status=" + status);
-	}
+  public InvalidLectureStatusException(UUID lectureId, LectureStatus status) {
+    super("수정 가능한 강의 상태가 아닙니다. lectureId=" + lectureId + ", status=" + status);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidSortOrderException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidSortOrderException.java
@@ -4,6 +4,6 @@ import com.goggles.common.exception.BadRequestException;
 
 public class InvalidSortOrderException extends BadRequestException {
   public InvalidSortOrderException(int sortOrder) {
-    super(LectureErrorCode.CHAPTER_DUPLICATE_SORT_ORDER.getMessage() + " sortOrder=" + sortOrder);
+    super(LectureErrorCode.CHAPTER_INVALID_SORT_ORDER.getMessage() + " sortOrder=" + sortOrder);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidSortOrderException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/InvalidSortOrderException.java
@@ -4,6 +4,6 @@ import com.goggles.common.exception.BadRequestException;
 
 public class InvalidSortOrderException extends BadRequestException {
   public InvalidSortOrderException(int sortOrder) {
-    super(LectureErrorCode.INVALID_SORT_ORDER.getMessage() + " sortOrder=" + sortOrder);
+    super(LectureErrorCode.CHAPTER_DUPLICATE_SORT_ORDER.getMessage() + " sortOrder=" + sortOrder);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -13,11 +13,25 @@ public enum LectureErrorCode {
   LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
   LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
   LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
+  LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
+  LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
+  LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
 
   // 챕터
   CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
   CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
-  INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다.");
+  CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
+  CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
+  CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
+  CHAPTER_DURATION_NEGATIVE("영상 길이는 0 이상이어야 합니다."),
+
+  // 가격
+  PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
+
+  // 강사
+  INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+  INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+  INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
 
   private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -23,7 +23,7 @@ public enum LectureErrorCode {
   CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
   CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
   CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
-  CHAPTER_DURATION_NEGATIVE("영상 길이는 0 이상이어야 합니다."),
+  CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
 
   // 가격
   PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -24,6 +24,9 @@ public enum LectureErrorCode {
   CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
   CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
   CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
+  CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
+  CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
+  CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
 
   // 가격
   PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
@@ -1,18 +1,5 @@
 package com.goggles.lecture_service.presentation.lecture;
 
-import java.util.UUID;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.LectureService;
@@ -24,50 +11,59 @@ import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateRequest
 import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateResponse;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateRequest;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateResponse;
-
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/lectures")
 @RequiredArgsConstructor
 public class LectureController {
 
-	private final LectureService lectureService;
+  private final LectureService lectureService;
 
-	// 강의 목록 조회 (교육생용 - PUBLISHED만)
-	@GetMapping
-	public CommonPageResponse<LectureSummary> getLectures(
-		@ModelAttribute LectureListQuery query, CommonPageRequest pageRequest) {
-		return lectureService.getLectures(query.toCondition(), pageRequest);
-	}
+  // 강의 목록 조회 (교육생용 - PUBLISHED만)
+  @GetMapping
+  public CommonPageResponse<LectureSummary> getLectures(
+      @ModelAttribute LectureListQuery query, CommonPageRequest pageRequest) {
+    return lectureService.getLectures(query.toCondition(), pageRequest);
+  }
 
-	// 강의 상세 조회
-	@GetMapping("/{lectureId}")
-	public LectureDetail getLectureDetail(@PathVariable UUID lectureId) {
-		return lectureService.getLectureDetail(lectureId);
-	}
+  // 강의 상세 조회
+  @GetMapping("/{lectureId}")
+  public LectureDetail getLectureDetail(@PathVariable UUID lectureId) {
+    return lectureService.getLectureDetail(lectureId);
+  }
 
-	// 강의 생성
-	// TODO: 추후 강사 활성/비활성 상태 검증이 필요하면 user-service Feign 호출 추가
-	@PostMapping
-	@ResponseStatus(HttpStatus.CREATED)
-	public LectureCreateResponse createLecture(
-		@RequestHeader("X-User-Id") UUID instructorId,
-		@RequestHeader("X-User-Name") String instructorName,
-		@Valid @RequestBody LectureCreateRequest request) {
-		return LectureCreateResponse.from(
-			lectureService.createLecture(request.toCommand(instructorId, instructorName)));
-	}
+  // 강의 생성
+  // TODO: 추후 강사 활성/비활성 상태 검증이 필요하면 user-service Feign 호출 추가
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public LectureCreateResponse createLecture(
+      @RequestHeader("X-User-Id") UUID instructorId,
+      @RequestHeader("X-User-Name") String instructorName,
+      @Valid @RequestBody LectureCreateRequest request) {
+    return LectureCreateResponse.from(
+        lectureService.createLecture(request.toCommand(instructorId, instructorName)));
+  }
 
-	// 챕터 생성
-	@PostMapping("/{lectureId}/chapters")
-	@ResponseStatus(HttpStatus.CREATED)
-	public ChapterCreateResponse createChapter(
-		// TODO(#3 user-service 로그인 API 연동 후): instructorId 일치 검증
-		@PathVariable UUID lectureId,
-		@Valid @RequestBody ChapterCreateRequest request) {
-		ChapterCreateResult result = lectureService.createChapter(request.toCommand(lectureId));
-		return ChapterCreateResponse.from(result);
-	}
+  // 챕터 생성
+  @PostMapping("/{lectureId}/chapters")
+  @ResponseStatus(HttpStatus.CREATED)
+  public ChapterCreateResponse createChapter(
+      // TODO(#3 user-service 로그인 API 연동 후): instructorId 일치 검증
+      @PathVariable UUID lectureId, @Valid @RequestBody ChapterCreateRequest request) {
+    ChapterCreateResult result = lectureService.createChapter(request.toCommand(lectureId));
+    return ChapterCreateResponse.from(result);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
@@ -61,8 +61,11 @@ public class LectureController {
   @PostMapping("/{lectureId}/chapters")
   @ResponseStatus(HttpStatus.CREATED)
   public ChapterCreateResponse createChapter(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Name") String userName,
       // TODO(#3 user-service 로그인 API 연동 후): instructorId 일치 검증
-      @PathVariable UUID lectureId, @Valid @RequestBody ChapterCreateRequest request) {
+      @PathVariable UUID lectureId,
+      @Valid @RequestBody ChapterCreateRequest request) {
     ChapterCreateResult result = lectureService.createChapter(request.toCommand(lectureId));
     return ChapterCreateResponse.from(result);
   }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
@@ -3,9 +3,12 @@ package com.goggles.lecture_service.presentation.lecture;
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.LectureService;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureListQuery;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateRequest;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateResponse;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateRequest;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateResponse;
 import jakarta.validation.Valid;
@@ -52,5 +55,18 @@ public class LectureController {
       @Valid @RequestBody LectureCreateRequest request) {
     return LectureCreateResponse.from(
         lectureService.createLecture(request.toCommand(instructorId, instructorName)));
+  }
+
+  // 챕터 생성
+  @PostMapping("/{lectureId}/chapters")
+  @ResponseStatus(HttpStatus.CREATED)
+  public ChapterCreateResponse createChapter(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Name") String userName,
+      @PathVariable UUID lectureId,
+      @Valid @RequestBody ChapterCreateRequest request) {
+
+    ChapterCreateResult result = lectureService.createChapter(request.toCommand(lectureId));
+    return ChapterCreateResponse.from(result);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
@@ -1,19 +1,7 @@
 package com.goggles.lecture_service.presentation.lecture;
 
-import com.goggles.common.pagination.CommonPageRequest;
-import com.goggles.common.pagination.CommonPageResponse;
-import com.goggles.lecture_service.application.lecture.LectureService;
-import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
-import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
-import com.goggles.lecture_service.application.lecture.query.dto.LectureListQuery;
-import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
-import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateRequest;
-import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateResponse;
-import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateRequest;
-import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateResponse;
-import jakarta.validation.Valid;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -25,48 +13,61 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goggles.common.pagination.CommonPageRequest;
+import com.goggles.common.pagination.CommonPageResponse;
+import com.goggles.lecture_service.application.lecture.LectureService;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
+import com.goggles.lecture_service.application.lecture.query.dto.LectureListQuery;
+import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateRequest;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateResponse;
+import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateRequest;
+import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/api/v1/lectures")
 @RequiredArgsConstructor
 public class LectureController {
 
-  private final LectureService lectureService;
+	private final LectureService lectureService;
 
-  // 강의 목록 조회 (교육생용 - PUBLISHED만)
-  @GetMapping
-  public CommonPageResponse<LectureSummary> getLectures(
-      @ModelAttribute LectureListQuery query, CommonPageRequest pageRequest) {
-    return lectureService.getLectures(query.toCondition(), pageRequest);
-  }
+	// 강의 목록 조회 (교육생용 - PUBLISHED만)
+	@GetMapping
+	public CommonPageResponse<LectureSummary> getLectures(
+		@ModelAttribute LectureListQuery query, CommonPageRequest pageRequest) {
+		return lectureService.getLectures(query.toCondition(), pageRequest);
+	}
 
-  // 강의 상세 조회
-  @GetMapping("/{lectureId}")
-  public LectureDetail getLectureDetail(@PathVariable UUID lectureId) {
-    return lectureService.getLectureDetail(lectureId);
-  }
+	// 강의 상세 조회
+	@GetMapping("/{lectureId}")
+	public LectureDetail getLectureDetail(@PathVariable UUID lectureId) {
+		return lectureService.getLectureDetail(lectureId);
+	}
 
-  // 강의 생성
-  // TODO: 추후 강사 활성/비활성 상태 검증이 필요하면 user-service Feign 호출 추가
-  @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
-  public LectureCreateResponse createLecture(
-      @RequestHeader("X-User-Id") UUID instructorId,
-      @RequestHeader("X-User-Name") String instructorName,
-      @Valid @RequestBody LectureCreateRequest request) {
-    return LectureCreateResponse.from(
-        lectureService.createLecture(request.toCommand(instructorId, instructorName)));
-  }
+	// 강의 생성
+	// TODO: 추후 강사 활성/비활성 상태 검증이 필요하면 user-service Feign 호출 추가
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public LectureCreateResponse createLecture(
+		@RequestHeader("X-User-Id") UUID instructorId,
+		@RequestHeader("X-User-Name") String instructorName,
+		@Valid @RequestBody LectureCreateRequest request) {
+		return LectureCreateResponse.from(
+			lectureService.createLecture(request.toCommand(instructorId, instructorName)));
+	}
 
-  // 챕터 생성
-  @PostMapping("/{lectureId}/chapters")
-  @ResponseStatus(HttpStatus.CREATED)
-  public ChapterCreateResponse createChapter(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Name") String userName,
-      @PathVariable UUID lectureId,
-      @Valid @RequestBody ChapterCreateRequest request) {
-
-    ChapterCreateResult result = lectureService.createChapter(request.toCommand(lectureId));
-    return ChapterCreateResponse.from(result);
-  }
+	// 챕터 생성
+	@PostMapping("/{lectureId}/chapters")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ChapterCreateResponse createChapter(
+		// TODO(#3 user-service 로그인 API 연동 후): instructorId 일치 검증
+		@PathVariable UUID lectureId,
+		@Valid @RequestBody ChapterCreateRequest request) {
+		ChapterCreateResult result = lectureService.createChapter(request.toCommand(lectureId));
+		return ChapterCreateResponse.from(result);
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterCreateRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterCreateRequest.java
@@ -1,0 +1,17 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ChapterCreateRequest(
+    @NotBlank String title,
+    @NotBlank String content,
+    @NotNull @Min(1) Integer sortOrder,
+    @NotNull @Min(1) Integer durationSeconds) {
+  public ChapterCreateCommand toCommand(UUID lectureId) {
+    return new ChapterCreateCommand(lectureId, title, content, sortOrder, durationSeconds);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterCreateResponse.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterCreateResponse.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import java.util.UUID;
+
+public record ChapterCreateResponse(UUID lectureId, UUID chapterId) {
+  public static ChapterCreateResponse from(ChapterCreateResult result) {
+    return new ChapterCreateResponse(result.lectureId(), result.chapterId());
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     import: optional:file:.env[.properties]
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goggles
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:goggles}
     username: ${DB_USERNAME:goggles}
     password: ${DB_PASSWORD:goggles}
     driver-class-name: org.postgresql.Driver

--- a/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
@@ -12,8 +12,10 @@ import com.goggles.lecture_service.application.lecture.command.service.LectureCo
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import com.goggles.lecture_service.domain.lecture.exception.DuplicateSortOrderException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidCategoryException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
 import java.util.Optional;
@@ -158,12 +160,13 @@ class LectureCommandServiceImplTest {
     @DisplayName("성공: DRAFT 강의에 챕터를 추가한다")
     void createChapter_success() {
       // given
-      ChapterCreateCommand command = new ChapterCreateCommand(lectureId, "1강", "자바 소개", 1, 600);
+      ChapterCreateCommand chapterCommand =
+          new ChapterCreateCommand(lectureId, "1강", "자바 소개", 1, 600);
 
       when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
 
       // when
-      ChapterCreateResult result = lectureCommandService.createChapter(command);
+      ChapterCreateResult result = lectureCommandService.createChapter(chapterCommand);
 
       // then
       assertThat(result).isNotNull();
@@ -178,16 +181,59 @@ class LectureCommandServiceImplTest {
     void createChapter_lectureNotFound_throws() {
       // given
       UUID notFoundId = UUID.randomUUID();
-      ChapterCreateCommand command = new ChapterCreateCommand(notFoundId, "1강", "자바 소개", 1, 600);
+      ChapterCreateCommand chapterCommand =
+          new ChapterCreateCommand(notFoundId, "1강", "자바 소개", 1, 600);
 
       when(lectureRepository.findById(notFoundId)).thenReturn(Optional.empty());
 
       // when & then
-      assertThatThrownBy(() -> lectureCommandService.createChapter(command))
+      assertThatThrownBy(() -> lectureCommandService.createChapter(chapterCommand))
           .isInstanceOf(LectureNotFoundException.class);
 
       verify(lectureRepository).findById(notFoundId);
       verify(lectureRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("실패: DRAFT 상태가 아닌 강의에 챕터 추가 시 예외 발생")
+    void createChapter_notDraftStatus_throws() {
+      // given - PENDING_REVIEW 상태로 만들기 위해 챕터 1개 추가 후 submitForReview
+      lecture.addChapter("dummy", "dummy", 1, 600);
+      lecture.submitForReview();
+
+      ChapterCreateCommand chapterCommand = new ChapterCreateCommand(lectureId, "2강", "내용", 2, 600);
+      when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+
+      // when & then
+      assertThatThrownBy(() -> lectureCommandService.createChapter(chapterCommand))
+          .isInstanceOf(InvalidLectureStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: sortOrder 가 중복되면 예외 발생")
+    void createChapter_duplicateSortOrder_throws() {
+      // given - 이미 sortOrder=1인 챕터 추가
+      lecture.addChapter("1강", "내용", 1, 600);
+
+      ChapterCreateCommand chapterCommand =
+          new ChapterCreateCommand(lectureId, "다른강", "내용", 1, 600);
+      when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+
+      // when & then
+      assertThatThrownBy(() -> lectureCommandService.createChapter(chapterCommand))
+          .isInstanceOf(DuplicateSortOrderException.class);
+    }
+
+    @Test
+    @DisplayName("실패: durationSeconds = 0 이면 예외 발생 (정책 강화)")
+    void createChapter_zeroDuration_throws() {
+      // given
+      ChapterCreateCommand chapterCommand = new ChapterCreateCommand(lectureId, "1강", "내용", 1, 0);
+      when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+
+      // when & then
+      assertThatThrownBy(() -> lectureCommandService.createChapter(chapterCommand))
+          .isInstanceOf(InvalidLectureFieldException.class);
     }
   }
 }

--- a/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 import com.goggles.lecture_service.application.lecture.command.service.LectureCommandServiceImpl;
@@ -11,7 +13,10 @@ import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidCategoryException;
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -114,7 +119,7 @@ class LectureCommandServiceImplTest {
 
       // when & then
       assertThatThrownBy(() -> lectureCommandService.createLecture(invalidCommand))
-          .isInstanceOf(IllegalArgumentException.class);
+          .isInstanceOf(InvalidLectureFieldException.class);
       verify(lectureRepository, times(0)).save(any(Lecture.class));
     }
 
@@ -128,8 +133,61 @@ class LectureCommandServiceImplTest {
 
       // when & then
       assertThatThrownBy(() -> lectureCommandService.createLecture(invalidCommand))
-          .isInstanceOf(IllegalArgumentException.class);
+          .isInstanceOf(InvalidLectureFieldException.class);
       verify(lectureRepository, times(0)).save(any(Lecture.class));
+    }
+
+    @Nested
+    @DisplayName("챕터 생성")
+    class CreateChapter {
+
+      private UUID lectureId;
+      private Lecture lecture;
+
+      @BeforeEach
+      void setUp() {
+        lecture =
+            Lecture.create(
+                instructorId, "강사이름", "IT", "자바 강의", "부제", "설명", DurationPolicy.DAYS_365, 50000L);
+
+        lectureId = lecture.getId();
+      }
+
+      @Test
+      @DisplayName("성공: DRAFT 강의에 챕터를 추가한다")
+      void createChapter_success() {
+        // given
+        ChapterCreateCommand command = new ChapterCreateCommand(lectureId, "1강", "자바 소개", 1, 600);
+
+        when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+
+        // when
+        ChapterCreateResult result = lectureCommandService.createChapter(command);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.lectureId()).isEqualTo(lectureId);
+        assertThat(result.chapterId()).isNotNull();
+
+        verify(lectureRepository).findById(lectureId);
+      }
+
+      @Test
+      @DisplayName("실패: 존재하지 않는 강의이면 예외 발생")
+      void createChapter_lectureNotFound_throws() {
+        // given
+        UUID notFoundId = UUID.randomUUID();
+        ChapterCreateCommand command = new ChapterCreateCommand(notFoundId, "1강", "자바 소개", 1, 600);
+
+        when(lectureRepository.findById(notFoundId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> lectureCommandService.createChapter(command))
+            .isInstanceOf(LectureNotFoundException.class);
+
+        verify(lectureRepository).findById(notFoundId);
+        verify(lectureRepository, never()).save(any());
+      }
     }
   }
 }

--- a/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
@@ -136,58 +136,58 @@ class LectureCommandServiceImplTest {
           .isInstanceOf(InvalidLectureFieldException.class);
       verify(lectureRepository, times(0)).save(any(Lecture.class));
     }
+  }
 
-    @Nested
-    @DisplayName("챕터 생성")
-    class CreateChapter {
+  @Nested
+  @DisplayName("챕터 생성")
+  class CreateChapter {
 
-      private UUID lectureId;
-      private Lecture lecture;
+    private UUID lectureId;
+    private Lecture lecture;
 
-      @BeforeEach
-      void setUp() {
-        lecture =
-            Lecture.create(
-                instructorId, "강사이름", "IT", "자바 강의", "부제", "설명", DurationPolicy.DAYS_365, 50000L);
+    @BeforeEach
+    void setUp() {
+      lecture =
+          Lecture.create(
+              instructorId, "강사이름", "IT", "자바 강의", "부제", "설명", DurationPolicy.DAYS_365, 50000L);
 
-        lectureId = lecture.getId();
-      }
+      lectureId = lecture.getId();
+    }
 
-      @Test
-      @DisplayName("성공: DRAFT 강의에 챕터를 추가한다")
-      void createChapter_success() {
-        // given
-        ChapterCreateCommand command = new ChapterCreateCommand(lectureId, "1강", "자바 소개", 1, 600);
+    @Test
+    @DisplayName("성공: DRAFT 강의에 챕터를 추가한다")
+    void createChapter_success() {
+      // given
+      ChapterCreateCommand command = new ChapterCreateCommand(lectureId, "1강", "자바 소개", 1, 600);
 
-        when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+      when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
 
-        // when
-        ChapterCreateResult result = lectureCommandService.createChapter(command);
+      // when
+      ChapterCreateResult result = lectureCommandService.createChapter(command);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.lectureId()).isEqualTo(lectureId);
-        assertThat(result.chapterId()).isNotNull();
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.lectureId()).isEqualTo(lectureId);
+      assertThat(result.chapterId()).isNotNull();
 
-        verify(lectureRepository).findById(lectureId);
-      }
+      verify(lectureRepository).findById(lectureId);
+    }
 
-      @Test
-      @DisplayName("실패: 존재하지 않는 강의이면 예외 발생")
-      void createChapter_lectureNotFound_throws() {
-        // given
-        UUID notFoundId = UUID.randomUUID();
-        ChapterCreateCommand command = new ChapterCreateCommand(notFoundId, "1강", "자바 소개", 1, 600);
+    @Test
+    @DisplayName("실패: 존재하지 않는 강의이면 예외 발생")
+    void createChapter_lectureNotFound_throws() {
+      // given
+      UUID notFoundId = UUID.randomUUID();
+      ChapterCreateCommand command = new ChapterCreateCommand(notFoundId, "1강", "자바 소개", 1, 600);
 
-        when(lectureRepository.findById(notFoundId)).thenReturn(Optional.empty());
+      when(lectureRepository.findById(notFoundId)).thenReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> lectureCommandService.createChapter(command))
-            .isInstanceOf(LectureNotFoundException.class);
+      // when & then
+      assertThatThrownBy(() -> lectureCommandService.createChapter(command))
+          .isInstanceOf(LectureNotFoundException.class);
 
-        verify(lectureRepository).findById(notFoundId);
-        verify(lectureRepository, never()).save(any());
-      }
+      verify(lectureRepository).findById(notFoundId);
+      verify(lectureRepository, never()).save(any());
     }
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #6

### 💡 작업 내용
- 강의 챕터 생성 API (POST /api/v1/lectures/{lectureId}/chapters) 구현
- Lecture.addChapter() 도메인 메서드를 통한 챕터 추가 (애그리거트 루트 경유)
- VO 검증 예외를 도메인 예외(`InvalidLectureFieldException`)로 통일
- VO 5개(`LectureContent`, `ChapterContent`, `Money`, `ChapterDuration`, `Instructor`)에 `@Getter` 적용
- LectureErrorCode 에 VO 검증용 메시지 카탈로그 추가
- 챕터 생성/실패 케이스 단위 테스트 추가

### 🔍 변경 이유
- VO 들이 `IllegalArgumentException` + 한글 문자열로 검증 메시지를 흩뿌려 관리하고 있어, common-library의 `CustomException` 기반 도메인 예외 패턴과 일관성이 깨져 있었음
- 메시지를 `LectureErrorCode` 한 곳으로 모음
- `@Getter` 미적용 VO 들을 엔티티 스타일과 통일하여 수동 getter 제거 → 코드 간결화

### 📝 리뷰 포인트
- VO 검증 실패를 단일 예외(`InvalidLectureFieldException`) + ErrorCode 로 처리한 방식이 적절한지 (개별 예외 클래스로 쪼갤지 vs 현재 방식 유지)
- `ChapterDuration` 검증 정책: 0초 허용 → `seconds >= 1` 로 강화 (Request 의 `@Min(1)` 과 일치)

### 🧠 기타 참고 사항
- 컨트롤러의 `X-User-Id` / `X-User-Name` 헤더는 user-service 로그인 API 연동 후 본인 강의 검증에 사용 예정 (`TODO` 주석으로 명시)
- 챕터 수정/삭제/순서 변경 API 는 후속 이슈에서 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 강의 내 챕터 생성 기능 추가 및 챕터 생성용 POST API 제공 (201 Created)

* **Improvements**
  * 필드 유효성 검사 오류 메시지 및 오류 코드 세분화로 보다 명확한 에러 응답 제공
  * 강의 생성/응답 형식 일부 변경(생성 결과가 응답 body 내 데이터로 포함)

* **Configuration**
  * 데이터베이스 연결을 환경 변수로 구성 가능하도록 변경

* **Tests**
  * 챕터 생성 성공/실패 시나리오 테스트 추가 및 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->