### PR TITLE
[FEAT] 수강 권한 Enrollment  도메인 구현 

### DIFF
--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -23,7 +24,10 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @Table(
     name = "p_enrollment",
-    uniqueConstraints = {})
+    indexes = {
+      @Index(name = "idx_enrollment_student_status", columnList = "student_id, status"),
+      @Index(name = "idx_enrollment_order_id", columnList = "order_id")
+    })
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -83,6 +87,7 @@ public class Enrollment extends BaseAudit {
 
   // 도메인 메서드 (상태 전이) — 기존과 동일
   public void activate(LocalDateTime now) {
+    validateNow(now);
     if (this.status != EnrollmentStatus.RESERVE) {
       throw new InvalidEnrollmentStatusException(
           EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE);
@@ -110,6 +115,7 @@ public class Enrollment extends BaseAudit {
 
   /** 사용자가 강의에 접근할 때 호출 (마지막 수강 시각 갱신) */
   public void touchLastAccessed(LocalDateTime now) {
+    validateNow(now);
     if (this.status != EnrollmentStatus.ACTIVE) {
       throw new InvalidEnrollmentStatusException(
           EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACCESS);
@@ -124,6 +130,7 @@ public class Enrollment extends BaseAudit {
   }
 
   public boolean isExpired(LocalDateTime now) {
+    validateNow(now);
     return this.expiresAt != null && now.isAfter(this.expiresAt);
   }
 
@@ -152,6 +159,12 @@ public class Enrollment extends BaseAudit {
     if (durationPolicy == null)
       throw new InvalidEnrollmentFieldException(
           EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
+  }
+
+  private static void validateNow(LocalDateTime now) {
+    if (now == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_TIME_REQUIRED);
+    }
   }
 
   private static LocalDateTime calculateExpiresAt(LocalDateTime from, DurationPolicy policy) {

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
@@ -1,0 +1,165 @@
+package com.goggles.lecture_service.domain.enrollment;
+
+import com.goggles.common.domain.BaseAudit;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentStatusException;
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(
+    name = "p_enrollment",
+    uniqueConstraints = {})
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Enrollment extends BaseAudit {
+
+  @Id
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id = UUID.randomUUID();
+
+  // 강의 스냅샷 (lectureId + lectureTitle + instructorId + instructorName)
+  @Embedded private LectureSnapshot lectureSnapshot;
+
+  @Column(name = "student_id", nullable = false)
+  private UUID studentId;
+
+  @Column(name = "order_id", nullable = false)
+  private UUID orderId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private EnrollmentStatus status;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "duration_policy", nullable = false, length = 20)
+  private DurationPolicy durationPolicy;
+
+  @Column(name = "activated_at")
+  private LocalDateTime activatedAt;
+
+  @Column(name = "expires_at")
+  private LocalDateTime expiresAt;
+
+  @Column(name = "last_accessed_at")
+  private LocalDateTime lastAccessedAt; // ← 추가
+
+  // 정적 팩토리 메서드: RESERVE 로 생성
+  public static Enrollment reserve(
+      LectureSnapshot lectureSnapshot,
+      UUID studentId,
+      UUID orderId,
+      DurationPolicy durationPolicy) {
+    validateRequired(lectureSnapshot, studentId, orderId, durationPolicy);
+    return new Enrollment(lectureSnapshot, studentId, orderId, durationPolicy);
+  }
+
+  private Enrollment(
+      LectureSnapshot lectureSnapshot,
+      UUID studentId,
+      UUID orderId,
+      DurationPolicy durationPolicy) {
+    this.lectureSnapshot = lectureSnapshot;
+    this.studentId = studentId;
+    this.orderId = orderId;
+    this.durationPolicy = durationPolicy;
+    this.status = EnrollmentStatus.RESERVE;
+  }
+
+  // 도메인 메서드 (상태 전이) — 기존과 동일
+  public void activate(LocalDateTime now) {
+    if (this.status != EnrollmentStatus.RESERVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE);
+    }
+    this.activatedAt = now;
+    this.expiresAt = calculateExpiresAt(now, this.durationPolicy);
+    this.status = EnrollmentStatus.ACTIVE;
+  }
+
+  public void cancel() {
+    if (this.status != EnrollmentStatus.RESERVE && this.status != EnrollmentStatus.ACTIVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_CANCEL);
+    }
+    this.status = EnrollmentStatus.CANCELED;
+  }
+
+  public void expire() {
+    if (this.status != EnrollmentStatus.ACTIVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_EXPIRE);
+    }
+    this.status = EnrollmentStatus.EXPIRED;
+  }
+
+  /** 사용자가 강의에 접근할 때 호출 (마지막 수강 시각 갱신) */
+  public void touchLastAccessed(LocalDateTime now) {
+    if (this.status != EnrollmentStatus.ACTIVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACCESS);
+    }
+    this.lastAccessedAt = now;
+  }
+
+  // 편의 메서드
+
+  public boolean isActive() {
+    return this.status == EnrollmentStatus.ACTIVE;
+  }
+
+  public boolean isExpired(LocalDateTime now) {
+    return this.expiresAt != null && now.isAfter(this.expiresAt);
+  }
+
+  // 스냅샷 내부 직접 접근
+  public UUID getLectureId() {
+    return this.lectureSnapshot.getLectureId();
+  }
+
+  public UUID getInstructorId() {
+    return this.lectureSnapshot.getInstructorId();
+  }
+
+  // 내부 검증
+  private static void validateRequired(
+      LectureSnapshot lectureSnapshot,
+      UUID studentId,
+      UUID orderId,
+      DurationPolicy durationPolicy) {
+    if (lectureSnapshot == null)
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
+    if (studentId == null)
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
+    if (orderId == null)
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ORDER_ID_REQUIRED);
+    if (durationPolicy == null)
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
+  }
+
+  private static LocalDateTime calculateExpiresAt(LocalDateTime from, DurationPolicy policy) {
+    return switch (policy) {
+      case DAYS_90 -> from.plusDays(90);
+      case DAYS_180 -> from.plusDays(180);
+      case DAYS_365 -> from.plusDays(365);
+      case UNLIMITED -> LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+    };
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/LectureSnapshot.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/LectureSnapshot.java
@@ -1,0 +1,59 @@
+package com.goggles.lecture_service.domain.enrollment;
+
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LectureSnapshot {
+
+  @Column(name = "lecture_id", nullable = false)
+  private UUID lectureId;
+
+  @Column(name = "lecture_title", nullable = false, length = 225)
+  private String lectureTitle;
+
+  @Column(name = "instructor_id", nullable = false)
+  private UUID instructorId;
+
+  @Column(name = "instructor_name", nullable = false, length = 100)
+  private String instructorName;
+
+  public static LectureSnapshot of(
+      UUID lectureId, String lectureTitle, UUID instructorId, String instructorName) {
+    validate(lectureId, lectureTitle, instructorId, instructorName);
+    return new LectureSnapshot(lectureId, lectureTitle, instructorId, instructorName);
+  }
+
+  private LectureSnapshot(
+      UUID lectureId, String lectureTitle, UUID instructorId, String instructorName) {
+    this.lectureId = lectureId;
+    this.lectureTitle = lectureTitle;
+    this.instructorId = instructorId;
+    this.instructorName = instructorName;
+  }
+
+  private static void validate(
+      UUID lectureId, String lectureTitle, UUID instructorId, String instructorName) {
+    if (lectureId == null)
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_LECTURE_ID_REQUIRED);
+    if (lectureTitle == null || lectureTitle.isBlank())
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_LECTURE_TITLE_REQUIRED);
+    if (instructorId == null)
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_INSTRUCTOR_ID_REQUIRED);
+    if (instructorName == null || instructorName.isBlank())
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_INSTRUCTOR_NAME_REQUIRED);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/enums/EnrollmentStatus.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/enums/EnrollmentStatus.java
@@ -1,0 +1,8 @@
+package com.goggles.lecture_service.domain.enrollment.enums;
+
+public enum EnrollmentStatus {
+  RESERVE, // 주문 생성 시 예약, 결제 대기 중
+  ACTIVE, // 결제 완료, 수강 가능
+  CANCELED, // 주문 취소 또는 환불
+  EXPIRED // 수강 기간 만료
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/DuplicateEnrollmentException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/DuplicateEnrollmentException.java
@@ -1,0 +1,15 @@
+package com.goggles.lecture_service.domain.enrollment.exception;
+
+import com.goggles.common.exception.ConflictException;
+import java.util.UUID;
+
+public class DuplicateEnrollmentException extends ConflictException {
+  public DuplicateEnrollmentException(UUID lectureId, UUID studentId) {
+    super(
+        EnrollmentErrorCode.ENROLLMENT_DUPLICATE.getMessage()
+            + " lectureId="
+            + lectureId
+            + ", studentId="
+            + studentId);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -1,0 +1,39 @@
+package com.goggles.lecture_service.domain.enrollment.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EnrollmentErrorCode {
+
+  // 조회
+  ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
+
+  // 중복
+  ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
+
+  // 상태 전이
+  ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
+
+  // 강의 검증
+  ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
+  ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
+
+  // 필수 필드 - 스냅샷
+  ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
+  ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+  ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
+  ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+  ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+
+  // 필수 필드 - 기타
+  ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
+  ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
+  ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다.");
+
+  private final String message;
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -33,7 +33,8 @@ public enum EnrollmentErrorCode {
   // 필수 필드 - 기타
   ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
   ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
-  ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다.");
+  ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
+  ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다.");
 
   private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.domain.enrollment.exception;
+
+import com.goggles.common.exception.NotFoundException;
+import java.util.UUID;
+
+public class EnrollmentNotFoundException extends NotFoundException {
+  public EnrollmentNotFoundException(UUID id) {
+    super(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND.getMessage() + " id=" + id);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/InvalidEnrollmentFieldException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/InvalidEnrollmentFieldException.java
@@ -1,0 +1,9 @@
+package com.goggles.lecture_service.domain.enrollment.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InvalidEnrollmentFieldException extends BadRequestException {
+  public InvalidEnrollmentFieldException(EnrollmentErrorCode errorCode) {
+    super(errorCode.getMessage());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/InvalidEnrollmentStatusException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/InvalidEnrollmentStatusException.java
@@ -1,0 +1,9 @@
+package com.goggles.lecture_service.domain.enrollment.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InvalidEnrollmentStatusException extends BadRequestException {
+  public InvalidEnrollmentStatusException(EnrollmentErrorCode errorCode) {
+    super(errorCode.getMessage());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,23 @@
+package com.goggles.lecture_service.domain.enrollment.repository;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface EnrollmentRepository {
+
+  Enrollment save(Enrollment enrollment);
+
+  Optional<Enrollment> findById(UUID id);
+
+  Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId);
+
+  // 동일 학생 + 동일 강의에 RESERVE/ACTIVE 인 enrollment 존재 여부. 중복 수강 검증용
+  boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId);
+
+  List<Enrollment> findAllByOrderId(UUID orderId);
+
+  // 학생의 ACTIVE 한 enrollment(내 강의 화면)
+  List<Enrollment> findActiveByStudentId(UUID studentId);
+}

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
@@ -1,0 +1,33 @@
+package com.goggles.lecture_service.infrastructure.enrollment.repository;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface EnrollmentJpaRepository extends JpaRepository<Enrollment, UUID> {
+
+  @Query(
+      "select e from Enrollment e "
+          + "where e.orderId = :orderId "
+          + "and e.lectureSnapshot.lectureId = :lectureId")
+  Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId);
+
+  @Query(
+      "select count(e) > 0 from Enrollment e "
+          + "where e.studentId = :studentId "
+          + "and e.lectureSnapshot.lectureId = :lectureId "
+          + "and e.status in (com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus.RESERVE, "
+          + "                 com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus.ACTIVE)")
+  boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId);
+
+  List<Enrollment> findAllByOrderId(UUID orderId);
+
+  @Query(
+      "select e from Enrollment e "
+          + "where e.studentId = :studentId "
+          + "and e.status = com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus.ACTIVE")
+  List<Enrollment> findActiveByStudentId(UUID studentId);
+}

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
@@ -1,11 +1,14 @@
 package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EnrollmentJpaRepository extends JpaRepository<Enrollment, UUID> {
 
@@ -13,21 +16,23 @@ public interface EnrollmentJpaRepository extends JpaRepository<Enrollment, UUID>
       "select e from Enrollment e "
           + "where e.orderId = :orderId "
           + "and e.lectureSnapshot.lectureId = :lectureId")
-  Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId);
+  Optional<Enrollment> findByOrderIdAndLectureId(
+      @Param("orderId") UUID orderId, @Param("lectureId") UUID lectureId);
 
   @Query(
       "select count(e) > 0 from Enrollment e "
           + "where e.studentId = :studentId "
           + "and e.lectureSnapshot.lectureId = :lectureId "
-          + "and e.status in (com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus.RESERVE, "
-          + "                 com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus.ACTIVE)")
-  boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId);
+          + "and e.status in :statuses")
+  boolean existsByStudentAndLectureAndStatusIn(
+      @Param("studentId") UUID studentId,
+      @Param("lectureId") UUID lectureId,
+      @Param("statuses") Collection<EnrollmentStatus> statuses);
 
   List<Enrollment> findAllByOrderId(UUID orderId);
 
   @Query(
-      "select e from Enrollment e "
-          + "where e.studentId = :studentId "
-          + "and e.status = com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus.ACTIVE")
-  List<Enrollment> findActiveByStudentId(UUID studentId);
+      "select e from Enrollment e " + "where e.studentId = :studentId " + "and e.status = :status")
+  List<Enrollment> findByStudentIdAndStatus(
+      @Param("studentId") UUID studentId, @Param("status") EnrollmentStatus status);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -1,9 +1,12 @@
 package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -11,6 +14,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class EnrollmentRepositoryImpl implements EnrollmentRepository {
+
+  private static final Set<EnrollmentStatus> ACTIVE_OR_RESERVED =
+      EnumSet.of(EnrollmentStatus.RESERVE, EnrollmentStatus.ACTIVE);
 
   private final EnrollmentJpaRepository jpaRepository;
 
@@ -31,7 +37,8 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
 
   @Override
   public boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId) {
-    return jpaRepository.existsActiveByStudentAndLecture(studentId, lectureId);
+    return jpaRepository.existsByStudentAndLectureAndStatusIn(
+        studentId, lectureId, ACTIVE_OR_RESERVED);
   }
 
   @Override
@@ -41,6 +48,6 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
 
   @Override
   public List<Enrollment> findActiveByStudentId(UUID studentId) {
-    return jpaRepository.findActiveByStudentId(studentId);
+    return jpaRepository.findByStudentIdAndStatus(studentId, EnrollmentStatus.ACTIVE);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.goggles.lecture_service.infrastructure.enrollment.repository;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EnrollmentRepositoryImpl implements EnrollmentRepository {
+
+  private final EnrollmentJpaRepository jpaRepository;
+
+  @Override
+  public Enrollment save(Enrollment enrollment) {
+    return jpaRepository.save(enrollment);
+  }
+
+  @Override
+  public Optional<Enrollment> findById(UUID id) {
+    return jpaRepository.findById(id);
+  }
+
+  @Override
+  public Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId) {
+    return jpaRepository.findByOrderIdAndLectureId(orderId, lectureId);
+  }
+
+  @Override
+  public boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId) {
+    return jpaRepository.existsActiveByStudentAndLecture(studentId, lectureId);
+  }
+
+  @Override
+  public List<Enrollment> findAllByOrderId(UUID orderId) {
+    return jpaRepository.findAllByOrderId(orderId);
+  }
+
+  @Override
+  public List<Enrollment> findActiveByStudentId(UUID studentId) {
+    return jpaRepository.findActiveByStudentId(studentId);
+  }
+}

--- a/src/test/java/com/goggles/lecture_service/EnrollmentTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentTest.java
@@ -1,0 +1,253 @@
+package com.goggles.lecture_service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.LectureSnapshot;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentStatusException;
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class EnrollmentTest {
+
+  private LectureSnapshot lectureSnapshot;
+  private UUID lectureId;
+  private UUID instructorId;
+  private UUID studentId;
+  private UUID orderId;
+
+  @BeforeEach
+  void setUp() {
+    lectureId = UUID.randomUUID();
+    instructorId = UUID.randomUUID();
+    studentId = UUID.randomUUID();
+    orderId = UUID.randomUUID();
+
+    lectureSnapshot = LectureSnapshot.of(lectureId, "스프링 부트 입문", instructorId, "홍길동");
+  }
+
+  @Nested
+  @DisplayName("LectureSnapshot 생성")
+  class SnapshotCreate {
+
+    @Test
+    @DisplayName("실패: lectureTitle 이 빈 문자열이면 예외")
+    void snapshot_blankTitle_throws() {
+      assertThatThrownBy(() -> LectureSnapshot.of(lectureId, "  ", instructorId, "홍길동"))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: instructorName 이 null 이면 예외")
+    void snapshot_nullInstructorName_throws() {
+      assertThatThrownBy(() -> LectureSnapshot.of(lectureId, "스프링", instructorId, null))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("Enrollment 예약 (RESERVE)")
+  class Reserve {
+
+    @Test
+    @DisplayName("성공: RESERVE 상태로 생성된다")
+    void reserve_success() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+
+      assertThat(enrollment).isNotNull();
+      assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.RESERVE);
+      assertThat(enrollment.getLectureId()).isEqualTo(lectureId);
+      assertThat(enrollment.getInstructorId()).isEqualTo(instructorId);
+      assertThat(enrollment.getLectureSnapshot().getLectureTitle()).isEqualTo("스프링 부트 입문");
+      assertThat(enrollment.getStudentId()).isEqualTo(studentId);
+      assertThat(enrollment.getOrderId()).isEqualTo(orderId);
+      assertThat(enrollment.getActivatedAt()).isNull();
+      assertThat(enrollment.getExpiresAt()).isNull();
+      assertThat(enrollment.getLastAccessedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("실패: lectureSnapshot 이 null 이면 예외")
+    void reserve_nullSnapshot_throws() {
+      assertThatThrownBy(
+              () -> Enrollment.reserve(null, studentId, orderId, DurationPolicy.DAYS_365))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: studentId 가 null 이면 예외")
+    void reserve_nullStudentId_throws() {
+      assertThatThrownBy(
+              () -> Enrollment.reserve(lectureSnapshot, null, orderId, DurationPolicy.DAYS_365))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: orderId 가 null 이면 예외")
+    void reserve_nullOrderId_throws() {
+      assertThatThrownBy(
+              () -> Enrollment.reserve(lectureSnapshot, studentId, null, DurationPolicy.DAYS_365))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: durationPolicy 가 null 이면 예외")
+    void reserve_nullDurationPolicy_throws() {
+      assertThatThrownBy(() -> Enrollment.reserve(lectureSnapshot, studentId, orderId, null))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("Enrollment 활성화 (ACTIVE)")
+  class Activate {
+
+    @Test
+    @DisplayName("성공: RESERVE → ACTIVE 전환되며 만료일이 설정된다")
+    void activate_success() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+      LocalDateTime now = LocalDateTime.now();
+
+      enrollment.activate(now);
+
+      assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.ACTIVE);
+      assertThat(enrollment.getActivatedAt()).isEqualTo(now);
+      assertThat(enrollment.getExpiresAt()).isEqualTo(now.plusDays(365));
+    }
+
+    @Test
+    @DisplayName("성공: UNLIMITED 정책이면 만료일이 9999년으로 설정된다")
+    void activate_unlimited_setsFarFuture() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.UNLIMITED);
+
+      enrollment.activate(LocalDateTime.now());
+
+      assertThat(enrollment.getExpiresAt().getYear()).isEqualTo(9999);
+    }
+
+    @Test
+    @DisplayName("실패: RESERVE 가 아닌 상태에서 activate 하면 예외")
+    void activate_notReserveStatus_throws() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+      enrollment.cancel();
+
+      assertThatThrownBy(() -> enrollment.activate(LocalDateTime.now()))
+          .isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("Enrollment 취소 (CANCEL)")
+  class Cancel {
+
+    @Test
+    @DisplayName("성공: RESERVE 상태에서 취소 가능")
+    void cancel_fromReserve_success() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+
+      enrollment.cancel();
+
+      assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("성공: ACTIVE 상태에서 취소 가능 (환불)")
+    void cancel_fromActive_success() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+      enrollment.activate(LocalDateTime.now());
+
+      enrollment.cancel();
+
+      assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("실패: 이미 CANCELED 인 enrollment 는 다시 취소 불가")
+    void cancel_alreadyCanceled_throws() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+      enrollment.cancel();
+
+      assertThatThrownBy(enrollment::cancel).isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("Enrollment 만료 (EXPIRE)")
+  class Expire {
+
+    @Test
+    @DisplayName("성공: ACTIVE → EXPIRED 전환")
+    void expire_fromActive_success() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+      enrollment.activate(LocalDateTime.now());
+
+      enrollment.expire();
+
+      assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("실패: RESERVE 상태에서 expire 호출 시 예외")
+    void expire_fromReserve_throws() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+
+      assertThatThrownBy(enrollment::expire).isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("최종 수강일시 (lastAccessedAt)")
+  class TouchLastAccessed {
+
+    @Test
+    @DisplayName("성공: ACTIVE 상태에서 lastAccessedAt 갱신")
+    void touch_fromActive_success() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+      enrollment.activate(LocalDateTime.now());
+      LocalDateTime accessTime = LocalDateTime.now();
+
+      enrollment.touchLastAccessed(accessTime);
+
+      assertThat(enrollment.getLastAccessedAt()).isEqualTo(accessTime);
+    }
+
+    @Test
+    @DisplayName("실패: RESERVE 상태에서 호출 시 예외")
+    void touch_fromReserve_throws() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+
+      assertThatThrownBy(() -> enrollment.touchLastAccessed(LocalDateTime.now()))
+          .isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: EXPIRED 상태에서 호출 시 예외")
+    void touch_fromExpired_throws() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+      enrollment.activate(LocalDateTime.now());
+      enrollment.expire();
+
+      assertThatThrownBy(() -> enrollment.touchLastAccessed(LocalDateTime.now()))
+          .isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+  }
+}


### PR DESCRIPTION
📌 관련 이슈

* close #14 

💡 작업 내용

* `Enrollment` 애그리거트 루트 도메인 설계 및 구현
* `EnrollmentStatus` enum 정의 (RESERVE, ACTIVE, CANCELED, EXPIRED)
* `LectureSnapshot` Embeddable VO 추가 (lectureId, lectureTitle, instructorId, instructorName 비정규화 보존)
* 정적 팩토리 메서드 `Enrollment.reserve()` 로 RESERVE 상태 생성
* 상태 전이 도메인 메서드 4종 구현
   * `activate(now)` — RESERVE → ACTIVE + DurationPolicy 기반 만료일 계산
   * `cancel()` — RESERVE/ACTIVE → CANCELED (주문 취소/환불)
   * `expire()` — ACTIVE → EXPIRED (스케줄러 기반 만료)
   * `touchLastAccessed(now)` — ACTIVE 상태 한정 최종 수강일 갱신
* `EnrollmentErrorCode` 정의 + 도메인 예외 4종 추가 (`EnrollmentNotFoundException`, `DuplicateEnrollmentException`, `InvalidEnrollmentStatusException`, `InvalidEnrollmentFieldException`)
* `EnrollmentRepository` 도메인 인터페이스 + 인프라 계층 분리 (DIP)
* 도메인 단위 테스트 추가 (`@Nested` + `@DisplayName` 시나리오 그룹화)

🔍 변경 이유

* 주문 서비스 연동 흐름(주문 생성 시 RESERVE → 결제 완료 시 ACTIVE) 을 위한 Enrollment 도메인이 필요
* MSA 사가 패턴 기반의 분산 트랜잭션 안전성을 위해 결제 전 RESERVE 단계로 자리 확보
* 강의/강사 정보 변경 또는 삭제와 무관하게 수강 이력의 일관성을 보장하기 위해 `LectureSnapshot` 으로 등록 시점 정보 박제
* `durationPolicy` 도 결제 시점 정책으로 보존 — 강의 정책 변경이 기존 수강생의 만료일에 영향 주지 않도록
* Lecture 도메인의 ErrorCode/Exception 패턴과 통일하여 `IllegalArgumentException` 대신 도메인 예외로 검증

📝 리뷰 포인트

* `LectureSnapshot` 을 Embeddable VO 로 분리한 방식이 적절한지 (개별 컬럼 평면 배치 vs 현재 방식 유지)
* `durationPolicy` 를 `LectureSnapshot` 안에 포함시키지 않고 별도 컬럼으로 둔 결정 — enrollment 의 만료 계산 로직과 직결되는 도메인 값이라 분리 유지
* `existsActiveByStudentAndLecture` 쿼리에서 메서드 이름 파싱 대신 `@Query + exists 서브쿼리` 채택 — Embedded 필드 접근 가독성 + RESERVE/ACTIVE 비즈니스 의미 캡슐화 목적
* 중복 수강 검증을 도메인이 아닌 application 계층으로 위임한 결정 — Repository 호출이 필요한 외부 데이터 검증이라 도메인은 자기 자신만 검증

🧠 기타 참고 사항

* 강의 인원 제한이 없는 VOD 모델 기준 (MVP 요구사항 문서) — 자리 차감 로직 없음
* 중복 수강 검증 로직, internal API (`/reserve`, `/cancellation`), Kafka 컨슈머 (`order.completion`, `order.cancellation`) 는 후속 이슈에서 진행
* `@SQLRestriction("deleted_at IS NULL")` soft delete 적용
* `last_accessed_at` 필드는 학생 수강 화면 진입 시 갱신 예정 (후속 이슈)
* DB 마이그레이션은 현재 `ddl-auto` 사용 중이라 자동 생성, Flyway 도입 시 partial index + 일반 인덱스 정리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 수강신청 상태 관리 추가(예약→활성/취소/만료), 유효기간 계산 및 무기한 처리
  * 강의 스냅샷(강의·강사 정보 보관)과 마지막 접근시간 기록
  * 중복 신청 방지 체크 및 관련 저장소 조회 기능
  * 도메인 수준의 오류 코드와 예외 처리 추가

* **테스트**
  * 수강신청 도메인 흐름(예약, 활성화, 취소, 만료, 접근 기록) 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->