### PR TITLE
[FEAT] 수강 예약 API

### DIFF
--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveCommand.java
@@ -4,5 +4,4 @@ import java.util.List;
 import java.util.UUID;
 
 public record LectureEnrollmentReserveCommand(
-	List<UUID> productIds, UUID userId, String userName) {
-}
+    List<UUID> productIds, UUID userId, String userName) {}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveCommand.java
@@ -1,7 +1,27 @@
 package com.goggles.lecture_service.application.enrollment.command.dto;
 
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
 import java.util.List;
 import java.util.UUID;
 
-public record LectureEnrollmentReserveCommand(
-    List<UUID> productIds, UUID userId, String userName) {}
+public record LectureEnrollmentReserveCommand(List<UUID> productIds, UUID userId, String userName) {
+
+  public LectureEnrollmentReserveCommand {
+    if (productIds == null) {
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_PRODUCT_IDS_REQUIRED);
+    }
+    if (productIds.isEmpty()) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_PRODUCT_IDS_EMPTY);
+    }
+    if (userId == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_USER_ID_REQUIRED);
+    }
+    if (userName == null || userName.isBlank()) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_USER_NAME_REQUIRED);
+    }
+
+    productIds = List.copyOf(productIds);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveCommand.java
@@ -1,0 +1,8 @@
+package com.goggles.lecture_service.application.enrollment.command.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record LectureEnrollmentReserveCommand(
+	List<UUID> productIds, UUID userId, String userName) {
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveResult.java
@@ -1,0 +1,25 @@
+package com.goggles.lecture_service.application.enrollment.command.dto;
+
+import java.util.UUID;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.lecture.Lecture;
+
+public record LectureEnrollmentReserveResult(
+	UUID enrollmentId,
+	UUID productId,
+	String productName,
+	Long productPrice,
+	UUID instructorId,
+	String instructorName) {
+
+	public static LectureEnrollmentReserveResult of(Enrollment enrollment, Lecture lecture) {
+		return new LectureEnrollmentReserveResult(
+			enrollment.getId(),
+			lecture.getId(),
+			lecture.getContent().getTitle(),
+			lecture.getPrice().getAmount(),
+			lecture.getInstructor().getInstructorId(),
+			lecture.getInstructor().getInstructorName());
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveResult.java
@@ -1,25 +1,24 @@
 package com.goggles.lecture_service.application.enrollment.command.dto;
 
-import java.util.UUID;
-
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import com.goggles.lecture_service.domain.lecture.Lecture;
+import java.util.UUID;
 
 public record LectureEnrollmentReserveResult(
-	UUID enrollmentId,
-	UUID productId,
-	String productName,
-	Long productPrice,
-	UUID instructorId,
-	String instructorName) {
+    UUID enrollmentId,
+    UUID productId,
+    String productName,
+    Long productPrice,
+    UUID instructorId,
+    String instructorName) {
 
-	public static LectureEnrollmentReserveResult of(Enrollment enrollment, Lecture lecture) {
-		return new LectureEnrollmentReserveResult(
-			enrollment.getId(),
-			lecture.getId(),
-			lecture.getContent().getTitle(),
-			lecture.getPrice().getAmount(),
-			lecture.getInstructor().getInstructorId(),
-			lecture.getInstructor().getInstructorName());
-	}
+  public static LectureEnrollmentReserveResult of(Enrollment enrollment, Lecture lecture) {
+    return new LectureEnrollmentReserveResult(
+        enrollment.getId(),
+        lecture.getId(),
+        lecture.getContent().getTitle(),
+        lecture.getPrice().getAmount(),
+        lecture.getInstructor().getInstructorId(),
+        lecture.getInstructor().getInstructorName());
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
@@ -1,11 +1,10 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
-import java.util.List;
-
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import java.util.List;
 
 public interface EnrollmentCommandService {
 
-	List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command);
+  List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
@@ -1,0 +1,11 @@
+package com.goggles.lecture_service.application.enrollment.command.service;
+
+import java.util.List;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+
+public interface EnrollmentCommandService {
+
+	List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command);
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -33,11 +33,10 @@ public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
     Map<UUID, Lecture> lectureMap =
         lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
-
-    // 2) productId 순서대로 검증,  Enrollment 생성
+    // 2) 전체 검증
     for (UUID productId : command.productIds()) {
       Lecture lecture = lectureMap.get(productId);
+
       if (lecture == null) {
         throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
       }
@@ -48,6 +47,12 @@ public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
         throw new EnrollmentReserveFailedException(
             productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
       }
+    }
+    // 3) 검증 통과 후 Enrollment 저장
+    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+
+    for (UUID productId : command.productIds()) {
+      Lecture lecture = lectureMap.get(productId);
 
       LectureSnapshot snapshot =
           LectureSnapshot.of(
@@ -58,6 +63,7 @@ public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
       Enrollment enrollment =
           Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+
       Enrollment saved = enrollmentRepository.save(enrollment);
 
       results.add(LectureEnrollmentReserveResult.of(saved, lecture));

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,14 +1,5 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
@@ -18,54 +9,60 @@ import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserve
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
-	private final LectureRepository lectureRepository;
-	private final EnrollmentRepository enrollmentRepository;
+  private final LectureRepository lectureRepository;
+  private final EnrollmentRepository enrollmentRepository;
 
-	@Override
-	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
-		// 1) 강의 일괄 조회
-		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
-		Map<UUID, Lecture> lectureMap =
-			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+  @Override
+  public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+    // 1) 강의 일괄 조회
+    List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+    Map<UUID, Lecture> lectureMap =
+        lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
-		// 2) productId 순서대로 검증,  Enrollment 생성
-		for (UUID productId : command.productIds()) {
-			Lecture lecture = lectureMap.get(productId);
-			if (lecture == null) {
-				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
-			}
-			if (!lecture.isOrderable()) {
-				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
-			}
-			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
-				throw new EnrollmentReserveFailedException(
-					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
-			}
+    // 2) productId 순서대로 검증,  Enrollment 생성
+    for (UUID productId : command.productIds()) {
+      Lecture lecture = lectureMap.get(productId);
+      if (lecture == null) {
+        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+      }
+      if (!lecture.isOrderable()) {
+        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
+      }
+      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+        throw new EnrollmentReserveFailedException(
+            productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+      }
 
-			LectureSnapshot snapshot =
-				LectureSnapshot.of(
-					lecture.getId(),
-					lecture.getContent().getTitle(),
-					lecture.getInstructor().getInstructorId(),
-					lecture.getInstructor().getInstructorName());
+      LectureSnapshot snapshot =
+          LectureSnapshot.of(
+              lecture.getId(),
+              lecture.getContent().getTitle(),
+              lecture.getInstructor().getInstructorId(),
+              lecture.getInstructor().getInstructorName());
 
-			Enrollment enrollment =
-				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
-			Enrollment saved = enrollmentRepository.save(enrollment);
+      Enrollment enrollment =
+          Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+      Enrollment saved = enrollmentRepository.save(enrollment);
 
-			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
-		}
+      results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+    }
 
-		return results;
-	}
+    return results;
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,0 +1,71 @@
+package com.goggles.lecture_service.application.enrollment.command.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.LectureSnapshot;
+import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
+
+	private final LectureRepository lectureRepository;
+	private final EnrollmentRepository enrollmentRepository;
+
+	@Override
+	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+		// 1) 강의 일괄 조회
+		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+		Map<UUID, Lecture> lectureMap =
+			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+
+		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+
+		// 2) productId 순서대로 검증,  Enrollment 생성
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
+			if (lecture == null) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+			}
+			if (!lecture.isOrderable()) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
+			}
+			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+				throw new EnrollmentReserveFailedException(
+					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+			}
+
+			LectureSnapshot snapshot =
+				LectureSnapshot.of(
+					lecture.getId(),
+					lecture.getContent().getTitle(),
+					lecture.getInstructor().getInstructorId(),
+					lecture.getInstructor().getInstructorName());
+
+			Enrollment enrollment =
+				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+			Enrollment saved = enrollmentRepository.save(enrollment);
+
+			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+		}
+
+		return results;
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
@@ -43,7 +43,7 @@ public class Enrollment extends BaseAudit {
   @Column(name = "student_id", nullable = false)
   private UUID studentId;
 
-  @Column(name = "order_id", nullable = false)
+  @Column(name = "order_id")
   private UUID orderId;
 
   @Enumerated(EnumType.STRING)
@@ -65,34 +65,29 @@ public class Enrollment extends BaseAudit {
 
   // 정적 팩토리 메서드: RESERVE 로 생성
   public static Enrollment reserve(
-      LectureSnapshot lectureSnapshot,
-      UUID studentId,
-      UUID orderId,
-      DurationPolicy durationPolicy) {
-    validateRequired(lectureSnapshot, studentId, orderId, durationPolicy);
-    return new Enrollment(lectureSnapshot, studentId, orderId, durationPolicy);
+      LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
+    validateRequired(lectureSnapshot, studentId, durationPolicy);
+    return new Enrollment(lectureSnapshot, studentId, durationPolicy);
   }
 
   private Enrollment(
-      LectureSnapshot lectureSnapshot,
-      UUID studentId,
-      UUID orderId,
-      DurationPolicy durationPolicy) {
+      LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
     this.lectureSnapshot = lectureSnapshot;
     this.studentId = studentId;
-    this.orderId = orderId;
     this.durationPolicy = durationPolicy;
     this.status = EnrollmentStatus.RESERVE;
   }
 
-  // 도메인 메서드 (상태 전이) — 기존과 동일
-  public void activate(LocalDateTime now) {
+  // 도메인 메서드 (상태 전이)
+  public void activate(LocalDateTime now, UUID orderId) {
     validateNow(now);
+    validateOrderId(orderId);
     if (this.status != EnrollmentStatus.RESERVE) {
       throw new InvalidEnrollmentStatusException(
           EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE);
     }
     this.activatedAt = now;
+    this.orderId = orderId;
     this.expiresAt = calculateExpiresAt(now, this.durationPolicy);
     this.status = EnrollmentStatus.ACTIVE;
   }
@@ -113,7 +108,7 @@ public class Enrollment extends BaseAudit {
     this.status = EnrollmentStatus.EXPIRED;
   }
 
-  /** 사용자가 강의에 접근할 때 호출 (마지막 수강 시각 갱신) */
+  // 사용자가 강의에 접근할 때 호출 (마지막 수강 시각 갱신)
   public void touchLastAccessed(LocalDateTime now) {
     validateNow(now);
     if (this.status != EnrollmentStatus.ACTIVE) {
@@ -145,20 +140,21 @@ public class Enrollment extends BaseAudit {
 
   // 내부 검증
   private static void validateRequired(
-      LectureSnapshot lectureSnapshot,
-      UUID studentId,
-      UUID orderId,
-      DurationPolicy durationPolicy) {
+      LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
     if (lectureSnapshot == null)
       throw new InvalidEnrollmentFieldException(
           EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
     if (studentId == null)
       throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
-    if (orderId == null)
-      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ORDER_ID_REQUIRED);
     if (durationPolicy == null)
       throw new InvalidEnrollmentFieldException(
           EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
+  }
+
+  private static void validateOrderId(UUID orderId) {
+    if (orderId == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ORDER_ID_REQUIRED);
+    }
   }
 
   private static void validateNow(LocalDateTime now) {

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/enums/ReserveFailReason.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/enums/ReserveFailReason.java
@@ -1,7 +1,7 @@
 package com.goggles.lecture_service.domain.enrollment.enums;
 
 public enum ReserveFailReason {
-	LECTURE_NOT_FOUND,
-	NOT_PUBLISHED,
-	DUPLICATE_ENROLLMENT
+  LECTURE_NOT_FOUND,
+  NOT_PUBLISHED,
+  DUPLICATE_ENROLLMENT
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/enums/ReserveFailReason.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/enums/ReserveFailReason.java
@@ -1,0 +1,7 @@
+package com.goggles.lecture_service.domain.enrollment.enums;
+
+public enum ReserveFailReason {
+	LECTURE_NOT_FOUND,
+	NOT_PUBLISHED,
+	DUPLICATE_ENROLLMENT
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -22,6 +22,7 @@ public enum EnrollmentErrorCode {
   // 강의 검증
   ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
   ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
+  ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
 
   // 필수 필드 - 스냅샷
   ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -35,7 +35,13 @@ public enum EnrollmentErrorCode {
   ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
   ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
   ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
-  ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다.");
+  ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
+
+  // 요청 필드 검증
+  ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
+  ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
+  ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+  ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
 
   private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentReserveFailedException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentReserveFailedException.java
@@ -1,23 +1,19 @@
 package com.goggles.lecture_service.domain.enrollment.exception;
 
-import java.util.UUID;
-
 import com.goggles.common.exception.BadRequestException;
 import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
-
+import java.util.UUID;
 import lombok.Getter;
 
 @Getter
 public class EnrollmentReserveFailedException extends BadRequestException {
 
-	private final UUID failedProductId;
-	private final ReserveFailReason reason;
+  private final UUID failedProductId;
+  private final ReserveFailReason reason;
 
-	public EnrollmentReserveFailedException(UUID failedProductId, ReserveFailReason reason) {
-		super(
-			String.format(
-				"수강 등록 예약 실패 - productId: %s, reason: %s", failedProductId, reason.name()));
-		this.failedProductId = failedProductId;
-		this.reason = reason;
-	}
+  public EnrollmentReserveFailedException(UUID failedProductId, ReserveFailReason reason) {
+    super(failedProductId.toString(), reason.name());
+    this.failedProductId = failedProductId;
+    this.reason = reason;
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentReserveFailedException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentReserveFailedException.java
@@ -1,0 +1,23 @@
+package com.goggles.lecture_service.domain.enrollment.exception;
+
+import java.util.UUID;
+
+import com.goggles.common.exception.BadRequestException;
+import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
+
+import lombok.Getter;
+
+@Getter
+public class EnrollmentReserveFailedException extends BadRequestException {
+
+	private final UUID failedProductId;
+	private final ReserveFailReason reason;
+
+	public EnrollmentReserveFailedException(UUID failedProductId, ReserveFailReason reason) {
+		super(
+			String.format(
+				"수강 등록 예약 실패 - productId: %s, reason: %s", failedProductId, reason.name()));
+		this.failedProductId = failedProductId;
+		this.reason = reason;
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,12 +1,5 @@
 package com.goggles.lecture_service.domain.lecture;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import org.hibernate.annotations.SQLRestriction;
-
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
@@ -17,7 +10,6 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldE
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -27,9 +19,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -38,196 +35,192 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-	@Id
-	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
-	private UUID id = UUID.randomUUID();
+  @Id
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id = UUID.randomUUID();
 
-	@Embedded
-	private Instructor instructor;
+  @Embedded private Instructor instructor;
 
-	@Column(nullable = false, length = 50)
-	private String category;
+  @Column(nullable = false, length = 50)
+  private String category;
 
-	@Embedded
-	private LectureContent content;
+  @Embedded private LectureContent content;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private DurationPolicy durationPolicy;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private DurationPolicy durationPolicy;
 
-	@Embedded
-	private Money price;
+  @Embedded private Money price;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private LectureStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private LectureStatus status;
 
-	@Column(columnDefinition = "TEXT")
-	private String rejectionReason;
+  @Column(columnDefinition = "TEXT")
+  private String rejectionReason;
 
-	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Chapter> chapters = new ArrayList<>();
+  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Chapter> chapters = new ArrayList<>();
 
-	// 정적 팩토리 메서드
+  // 정적 팩토리 메서드
 
-	public static Lecture create(
-		UUID instructorId,
-		String instructorName,
-		String category,
-		String title,
-		String subtitle,
-		String description,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
+  public static Lecture create(
+      UUID instructorId,
+      String instructorName,
+      String category,
+      String title,
+      String subtitle,
+      String description,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
 
-		validateCategory(category);
+    validateCategory(category);
 
-		return new Lecture(
-			new Instructor(instructorId, instructorName),
-			category,
-			new LectureContent(title, subtitle, description),
-			durationPolicy,
-			Money.of(priceAmount));
-	}
+    return new Lecture(
+        new Instructor(instructorId, instructorName),
+        category,
+        new LectureContent(title, subtitle, description),
+        durationPolicy,
+        Money.of(priceAmount));
+  }
 
-	private Lecture(
-		Instructor instructor,
-		String category,
-		LectureContent content,
-		DurationPolicy durationPolicy,
-		Money price) {
-		this.instructor = instructor;
-		this.category = category;
-		this.content = content;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = price;
-		this.status = LectureStatus.DRAFT;
-	}
+  private Lecture(
+      Instructor instructor,
+      String category,
+      LectureContent content,
+      DurationPolicy durationPolicy,
+      Money price) {
+    this.instructor = instructor;
+    this.category = category;
+    this.content = content;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = price;
+    this.status = LectureStatus.DRAFT;
+  }
 
-	// 도메인 메서드 (챕터 관리)
+  // 도메인 메서드 (챕터 관리)
 
-	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
-		validateDraftStatus();
-		validateDuplicateSortOrder(sortOrder);
+  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
+    validateDraftStatus();
+    validateDuplicateSortOrder(sortOrder);
 
-		ChapterContent chapterContent = new ChapterContent(title, content);
-		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+    ChapterContent chapterContent = new ChapterContent(title, content);
+    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-		chapters.add(chapter);
+    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+    chapters.add(chapter);
 
-		return chapter.getId();
-	}
+    return chapter.getId();
+  }
 
-	public void removeChapter(UUID chapterId) {
-		validateDraftStatus();
-		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-		if (!removed) {
-			throw new ChapterNotFoundException(chapterId);
-		}
-	}
+  public void removeChapter(UUID chapterId) {
+    validateDraftStatus();
+    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+    if (!removed) {
+      throw new ChapterNotFoundException(chapterId);
+    }
+  }
 
-	public void reorderChapter(UUID chapterId, int newSortOrder) {
-		validateDraftStatus();
-		Chapter target = findChapterById(chapterId);
-		if (target.getSortOrder() == newSortOrder)
-			return;
-		validateDuplicateSortOrder(newSortOrder);
-		target.updateSortOrder(newSortOrder);
-	}
+  public void reorderChapter(UUID chapterId, int newSortOrder) {
+    validateDraftStatus();
+    Chapter target = findChapterById(chapterId);
+    if (target.getSortOrder() == newSortOrder) return;
+    validateDuplicateSortOrder(newSortOrder);
+    target.updateSortOrder(newSortOrder);
+  }
 
-	public List<Chapter> getChapters() {
-		return Collections.unmodifiableList(chapters);
-	}
+  public List<Chapter> getChapters() {
+    return Collections.unmodifiableList(chapters);
+  }
 
-	// 도메인 메서드 (정보 수정)
+  // 도메인 메서드 (정보 수정)
 
-	public void updateMetadata(
-		String title,
-		String subtitle,
-		String description,
-		String category,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
-		validateDraftStatus();
-		validateCategory(category);
+  public void updateMetadata(
+      String title,
+      String subtitle,
+      String description,
+      String category,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
+    validateDraftStatus();
+    validateCategory(category);
 
-		this.content = new LectureContent(title, subtitle, description);
-		this.category = category;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = Money.of(priceAmount);
-	}
+    this.content = new LectureContent(title, subtitle, description);
+    this.category = category;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = Money.of(priceAmount);
+  }
 
-	// 도메인 메서드 (상태 전이)
+  // 도메인 메서드 (상태 전이)
 
-	public void submitForReview() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (chapters.isEmpty()) {
-			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-		}
-		this.status = LectureStatus.PENDING_REVIEW;
-		// 리뷰 재신청 시 이전 이유 삭제
-		this.rejectionReason = null;
-	}
+  public void submitForReview() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (chapters.isEmpty()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
+    }
+    this.status = LectureStatus.PENDING_REVIEW;
+    // 리뷰 재신청 시 이전 이유 삭제
+    this.rejectionReason = null;
+  }
 
-	public void approve() {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.PUBLISHED;
-		this.rejectionReason = null;
-	}
+  public void approve() {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.PUBLISHED;
+    this.rejectionReason = null;
+  }
 
-	public void reject(String reason) {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (reason == null || reason.isBlank()) {
-			throw new InvalidRejectionReasonException();
-		}
-		this.status = LectureStatus.DRAFT;
-		this.rejectionReason = reason;
-	}
+  public void reject(String reason) {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new InvalidRejectionReasonException();
+    }
+    this.status = LectureStatus.DRAFT;
+    this.rejectionReason = reason;
+  }
 
-	public void hide() {
-		if (this.status != LectureStatus.PUBLISHED) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.HIDDEN;
-	}
+  public void hide() {
+    if (this.status != LectureStatus.PUBLISHED) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.HIDDEN;
+  }
 
-	//주문 가능 여부
-	public boolean isOrderable() {
-		return this.status == LectureStatus.PUBLISHED;
-	}
+  // 주문 가능 여부
+  public boolean isOrderable() {
+    return this.status == LectureStatus.PUBLISHED;
+  }
 
-	// 내부 검증 및 편의 메서드
+  // 내부 검증 및 편의 메서드
 
-	private void validateDraftStatus() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-	}
+  private void validateDraftStatus() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+  }
 
-	private void validateDuplicateSortOrder(int sortOrder) {
-		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-		if (isDuplicate) {
-			throw new DuplicateSortOrderException(sortOrder);
-		}
-	}
+  private void validateDuplicateSortOrder(int sortOrder) {
+    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+    if (isDuplicate) {
+      throw new DuplicateSortOrderException(sortOrder);
+    }
+  }
 
-	private Chapter findChapterById(UUID chapterId) {
-		return chapters.stream()
-			.filter(c -> c.getId().equals(chapterId))
-			.findFirst()
-			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
-	}
+  private Chapter findChapterById(UUID chapterId) {
+    return chapters.stream()
+        .filter(c -> c.getId().equals(chapterId))
+        .findFirst()
+        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
+  }
 
-	private static void validateCategory(String category) {
-		if (category == null || category.isBlank()) {
-			throw new InvalidCategoryException();
-		}
-	}
+  private static void validateCategory(String category) {
+    if (category == null || category.isBlank()) {
+      throw new InvalidCategoryException();
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,5 +1,12 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.SQLRestriction;
+
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
@@ -10,6 +17,7 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldE
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -19,14 +27,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -35,187 +38,196 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-  @Id
-  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
-  private UUID id = UUID.randomUUID();
+	@Id
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id = UUID.randomUUID();
 
-  @Embedded private Instructor instructor;
+	@Embedded
+	private Instructor instructor;
 
-  @Column(nullable = false, length = 50)
-  private String category;
+	@Column(nullable = false, length = 50)
+	private String category;
 
-  @Embedded private LectureContent content;
+	@Embedded
+	private LectureContent content;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private DurationPolicy durationPolicy;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private DurationPolicy durationPolicy;
 
-  @Embedded private Money price;
+	@Embedded
+	private Money price;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private LectureStatus status;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private LectureStatus status;
 
-  @Column(columnDefinition = "TEXT")
-  private String rejectionReason;
+	@Column(columnDefinition = "TEXT")
+	private String rejectionReason;
 
-  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Chapter> chapters = new ArrayList<>();
+	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Chapter> chapters = new ArrayList<>();
 
-  // 정적 팩토리 메서드
+	// 정적 팩토리 메서드
 
-  public static Lecture create(
-      UUID instructorId,
-      String instructorName,
-      String category,
-      String title,
-      String subtitle,
-      String description,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
+	public static Lecture create(
+		UUID instructorId,
+		String instructorName,
+		String category,
+		String title,
+		String subtitle,
+		String description,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
 
-    validateCategory(category);
+		validateCategory(category);
 
-    return new Lecture(
-        new Instructor(instructorId, instructorName),
-        category,
-        new LectureContent(title, subtitle, description),
-        durationPolicy,
-        Money.of(priceAmount));
-  }
+		return new Lecture(
+			new Instructor(instructorId, instructorName),
+			category,
+			new LectureContent(title, subtitle, description),
+			durationPolicy,
+			Money.of(priceAmount));
+	}
 
-  private Lecture(
-      Instructor instructor,
-      String category,
-      LectureContent content,
-      DurationPolicy durationPolicy,
-      Money price) {
-    this.instructor = instructor;
-    this.category = category;
-    this.content = content;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = price;
-    this.status = LectureStatus.DRAFT;
-  }
+	private Lecture(
+		Instructor instructor,
+		String category,
+		LectureContent content,
+		DurationPolicy durationPolicy,
+		Money price) {
+		this.instructor = instructor;
+		this.category = category;
+		this.content = content;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = price;
+		this.status = LectureStatus.DRAFT;
+	}
 
-  // 도메인 메서드 (챕터 관리)
+	// 도메인 메서드 (챕터 관리)
 
-  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
-    validateDraftStatus();
-    validateDuplicateSortOrder(sortOrder);
+	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
+		validateDraftStatus();
+		validateDuplicateSortOrder(sortOrder);
 
-    ChapterContent chapterContent = new ChapterContent(title, content);
-    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+		ChapterContent chapterContent = new ChapterContent(title, content);
+		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-    chapters.add(chapter);
+		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+		chapters.add(chapter);
 
-    return chapter.getId();
-  }
+		return chapter.getId();
+	}
 
-  public void removeChapter(UUID chapterId) {
-    validateDraftStatus();
-    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-    if (!removed) {
-      throw new ChapterNotFoundException(chapterId);
-    }
-  }
+	public void removeChapter(UUID chapterId) {
+		validateDraftStatus();
+		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+		if (!removed) {
+			throw new ChapterNotFoundException(chapterId);
+		}
+	}
 
-  public void reorderChapter(UUID chapterId, int newSortOrder) {
-    validateDraftStatus();
-    Chapter target = findChapterById(chapterId);
-    if (target.getSortOrder() == newSortOrder) return;
-    validateDuplicateSortOrder(newSortOrder);
-    target.updateSortOrder(newSortOrder);
-  }
+	public void reorderChapter(UUID chapterId, int newSortOrder) {
+		validateDraftStatus();
+		Chapter target = findChapterById(chapterId);
+		if (target.getSortOrder() == newSortOrder)
+			return;
+		validateDuplicateSortOrder(newSortOrder);
+		target.updateSortOrder(newSortOrder);
+	}
 
-  public List<Chapter> getChapters() {
-    return Collections.unmodifiableList(chapters);
-  }
+	public List<Chapter> getChapters() {
+		return Collections.unmodifiableList(chapters);
+	}
 
-  // 도메인 메서드 (정보 수정)
+	// 도메인 메서드 (정보 수정)
 
-  public void updateMetadata(
-      String title,
-      String subtitle,
-      String description,
-      String category,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
-    validateDraftStatus();
-    validateCategory(category);
+	public void updateMetadata(
+		String title,
+		String subtitle,
+		String description,
+		String category,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
+		validateDraftStatus();
+		validateCategory(category);
 
-    this.content = new LectureContent(title, subtitle, description);
-    this.category = category;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = Money.of(priceAmount);
-  }
+		this.content = new LectureContent(title, subtitle, description);
+		this.category = category;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = Money.of(priceAmount);
+	}
 
-  // 도메인 메서드 (상태 전이)
+	// 도메인 메서드 (상태 전이)
 
-  public void submitForReview() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    if (chapters.isEmpty()) {
-      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-    }
-    this.status = LectureStatus.PENDING_REVIEW;
-    // 리뷰 재신청 시 이전 이유 삭제
-    this.rejectionReason = null;
-  }
+	public void submitForReview() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (chapters.isEmpty()) {
+			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
+		}
+		this.status = LectureStatus.PENDING_REVIEW;
+		// 리뷰 재신청 시 이전 이유 삭제
+		this.rejectionReason = null;
+	}
 
-  public void approve() {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    this.status = LectureStatus.PUBLISHED;
-    this.rejectionReason = null;
-  }
+	public void approve() {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.PUBLISHED;
+		this.rejectionReason = null;
+	}
 
-  public void reject(String reason) {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    if (reason == null || reason.isBlank()) {
-      throw new InvalidRejectionReasonException();
-    }
-    this.status = LectureStatus.DRAFT;
-    this.rejectionReason = reason;
-  }
+	public void reject(String reason) {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (reason == null || reason.isBlank()) {
+			throw new InvalidRejectionReasonException();
+		}
+		this.status = LectureStatus.DRAFT;
+		this.rejectionReason = reason;
+	}
 
-  public void hide() {
-    if (this.status != LectureStatus.PUBLISHED) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    this.status = LectureStatus.HIDDEN;
-  }
+	public void hide() {
+		if (this.status != LectureStatus.PUBLISHED) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.HIDDEN;
+	}
 
-  // 내부 검증 및 편의 메서드
+	//주문 가능 여부
+	public boolean isOrderable() {
+		return this.status == LectureStatus.PUBLISHED;
+	}
 
-  private void validateDraftStatus() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-  }
+	// 내부 검증 및 편의 메서드
 
-  private void validateDuplicateSortOrder(int sortOrder) {
-    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-    if (isDuplicate) {
-      throw new DuplicateSortOrderException(sortOrder);
-    }
-  }
+	private void validateDraftStatus() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+	}
 
-  private Chapter findChapterById(UUID chapterId) {
-    return chapters.stream()
-        .filter(c -> c.getId().equals(chapterId))
-        .findFirst()
-        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
-  }
+	private void validateDuplicateSortOrder(int sortOrder) {
+		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+		if (isDuplicate) {
+			throw new DuplicateSortOrderException(sortOrder);
+		}
+	}
 
-  private static void validateCategory(String category) {
-    if (category == null || category.isBlank()) {
-      throw new InvalidCategoryException();
-    }
-  }
+	private Chapter findChapterById(UUID chapterId) {
+		return chapters.stream()
+			.filter(c -> c.getId().equals(chapterId))
+			.findFirst()
+			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
+	}
+
+	private static void validateCategory(String category) {
+		if (category == null || category.isBlank()) {
+			throw new InvalidCategoryException();
+		}
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
@@ -1,21 +1,24 @@
 package com.goggles.lecture_service.domain.lecture.repository;
 
-import com.goggles.lecture_service.domain.lecture.Lecture;
-import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+
 public interface LectureRepository {
-  Lecture save(Lecture lecture);
+	Lecture save(Lecture lecture);
 
-  // 일반 조회 - @SQLRestriction으로 삭제된 거 자동 필터링
-  Optional<Lecture> findById(UUID id);
+	// 일반 조회 - @SQLRestriction으로 삭제된 거 자동 필터링
+	Optional<Lecture> findById(UUID id);
 
-  List<Lecture> findAllByInstructorId(UUID instructorId);
+	List<Lecture> findAllByInstructorId(UUID instructorId);
 
-  Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status);
+	Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status);
 
-  // 관리자 전용 - 삭제된 것도 포함
-  Optional<Lecture> findByIdIncludeDeleted(UUID id);
+	List<Lecture> findAllByIdIn(List<UUID> ids);
+
+	// 관리자 전용 - 삭제된 것도 포함
+	Optional<Lecture> findByIdIncludeDeleted(UUID id);
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureRepository.java
@@ -1,24 +1,23 @@
 package com.goggles.lecture_service.domain.lecture.repository;
 
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.goggles.lecture_service.domain.lecture.Lecture;
-import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
-
 public interface LectureRepository {
-	Lecture save(Lecture lecture);
+  Lecture save(Lecture lecture);
 
-	// 일반 조회 - @SQLRestriction으로 삭제된 거 자동 필터링
-	Optional<Lecture> findById(UUID id);
+  // 일반 조회 - @SQLRestriction으로 삭제된 거 자동 필터링
+  Optional<Lecture> findById(UUID id);
 
-	List<Lecture> findAllByInstructorId(UUID instructorId);
+  List<Lecture> findAllByInstructorId(UUID instructorId);
 
-	Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status);
+  Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status);
 
-	List<Lecture> findAllByIdIn(List<UUID> ids);
+  List<Lecture> findAllByIdIn(List<UUID> ids);
 
-	// 관리자 전용 - 삭제된 것도 포함
-	Optional<Lecture> findByIdIncludeDeleted(UUID id);
+  // 관리자 전용 - 삭제된 것도 포함
+  Optional<Lecture> findByIdIncludeDeleted(UUID id);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
@@ -1,25 +1,23 @@
 package com.goggles.lecture_service.infrastructure.lecture.repository;
 
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.goggles.lecture_service.domain.lecture.Lecture;
-import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
-
 public interface LectureJpaRepository extends JpaRepository<Lecture, UUID> {
 
-	List<Lecture> findAllByInstructor_InstructorId(UUID instructorId);
+  List<Lecture> findAllByInstructor_InstructorId(UUID instructorId);
 
-	// soft delete 필터 우회를 위해 native query 사용
-	@Query(value = "SELECT * FROM lecture.p_lecture WHERE id = :id", nativeQuery = true)
-	Optional<Lecture> findByIdIncludeDeleted(@Param("id") UUID id);
+  // soft delete 필터 우회를 위해 native query 사용
+  @Query(value = "SELECT * FROM lecture.p_lecture WHERE id = :id", nativeQuery = true)
+  Optional<Lecture> findByIdIncludeDeleted(@Param("id") UUID id);
 
-	List<Lecture> findAllByIdIn(List<UUID> ids);
+  List<Lecture> findAllByIdIn(List<UUID> ids);
 
-	Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status);
+  Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureJpaRepository.java
@@ -1,21 +1,25 @@
 package com.goggles.lecture_service.infrastructure.lecture.repository;
 
-import com.goggles.lecture_service.domain.lecture.Lecture;
-import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+
 public interface LectureJpaRepository extends JpaRepository<Lecture, UUID> {
 
-  List<Lecture> findAllByInstructor_InstructorId(UUID instructorId);
+	List<Lecture> findAllByInstructor_InstructorId(UUID instructorId);
 
-  // soft delete 필터 우회를 위해 native query 사용
-  @Query(value = "SELECT * FROM lecture.p_lecture WHERE id = :id", nativeQuery = true)
-  Optional<Lecture> findByIdIncludeDeleted(@Param("id") UUID id);
+	// soft delete 필터 우회를 위해 native query 사용
+	@Query(value = "SELECT * FROM lecture.p_lecture WHERE id = :id", nativeQuery = true)
+	Optional<Lecture> findByIdIncludeDeleted(@Param("id") UUID id);
 
-  Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status);
+	List<Lecture> findAllByIdIn(List<UUID> ids);
+
+	Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
@@ -1,50 +1,47 @@
 package com.goggles.lecture_service.infrastructure.lecture.repository;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.springframework.stereotype.Repository;
-
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class LectureRepositoryImpl implements LectureRepository {
 
-	private final LectureJpaRepository lectureJpaRepository;
+  private final LectureJpaRepository lectureJpaRepository;
 
-	@Override
-	public Lecture save(Lecture lecture) {
-		return lectureJpaRepository.save(lecture);
-	}
+  @Override
+  public Lecture save(Lecture lecture) {
+    return lectureJpaRepository.save(lecture);
+  }
 
-	@Override
-	public Optional<Lecture> findById(UUID id) {
-		return lectureJpaRepository.findById(id);
-	}
+  @Override
+  public Optional<Lecture> findById(UUID id) {
+    return lectureJpaRepository.findById(id);
+  }
 
-	@Override
-	public List<Lecture> findAllByInstructorId(UUID instructorId) {
-		return lectureJpaRepository.findAllByInstructor_InstructorId(instructorId);
-	}
+  @Override
+  public List<Lecture> findAllByInstructorId(UUID instructorId) {
+    return lectureJpaRepository.findAllByInstructor_InstructorId(instructorId);
+  }
 
-	@Override
-	public Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status) {
-		return lectureJpaRepository.findByIdAndStatus(id, status);
-	}
+  @Override
+  public Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status) {
+    return lectureJpaRepository.findByIdAndStatus(id, status);
+  }
 
-	@Override
-	public List<Lecture> findAllByIdIn(List<UUID> ids) {
-		return lectureJpaRepository.findAllByIdIn(ids);
-	}
+  @Override
+  public List<Lecture> findAllByIdIn(List<UUID> ids) {
+    return lectureJpaRepository.findAllByIdIn(ids);
+  }
 
-	@Override
-	public Optional<Lecture> findByIdIncludeDeleted(UUID id) {
-		return lectureJpaRepository.findByIdIncludeDeleted(id);
-	}
+  @Override
+  public Optional<Lecture> findByIdIncludeDeleted(UUID id) {
+    return lectureJpaRepository.findByIdIncludeDeleted(id);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureRepositoryImpl.java
@@ -1,42 +1,50 @@
 package com.goggles.lecture_service.infrastructure.lecture.repository;
 
-import com.goggles.lecture_service.domain.lecture.Lecture;
-import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
-import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
+
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
 public class LectureRepositoryImpl implements LectureRepository {
 
-  private final LectureJpaRepository lectureJpaRepository;
+	private final LectureJpaRepository lectureJpaRepository;
 
-  @Override
-  public Lecture save(Lecture lecture) {
-    return lectureJpaRepository.save(lecture);
-  }
+	@Override
+	public Lecture save(Lecture lecture) {
+		return lectureJpaRepository.save(lecture);
+	}
 
-  @Override
-  public Optional<Lecture> findById(UUID id) {
-    return lectureJpaRepository.findById(id);
-  }
+	@Override
+	public Optional<Lecture> findById(UUID id) {
+		return lectureJpaRepository.findById(id);
+	}
 
-  @Override
-  public List<Lecture> findAllByInstructorId(UUID instructorId) {
-    return lectureJpaRepository.findAllByInstructor_InstructorId(instructorId);
-  }
+	@Override
+	public List<Lecture> findAllByInstructorId(UUID instructorId) {
+		return lectureJpaRepository.findAllByInstructor_InstructorId(instructorId);
+	}
 
-  @Override
-  public Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status) {
-    return lectureJpaRepository.findByIdAndStatus(id, status);
-  }
+	@Override
+	public Optional<Lecture> findByIdAndStatus(UUID id, LectureStatus status) {
+		return lectureJpaRepository.findByIdAndStatus(id, status);
+	}
 
-  @Override
-  public Optional<Lecture> findByIdIncludeDeleted(UUID id) {
-    return lectureJpaRepository.findByIdIncludeDeleted(id);
-  }
+	@Override
+	public List<Lecture> findAllByIdIn(List<UUID> ids) {
+		return lectureJpaRepository.findAllByIdIn(ids);
+	}
+
+	@Override
+	public Optional<Lecture> findByIdIncludeDeleted(UUID id) {
+		return lectureJpaRepository.findByIdIncludeDeleted(id);
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
@@ -1,0 +1,31 @@
+package com.goggles.lecture_service.presentation.enrollment.internal;
+
+import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandService;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/lectures-enrollment")
+@RequiredArgsConstructor
+public class InternalLectureEnrollmentController {
+
+  private final EnrollmentCommandService enrollmentCommandService;
+
+  @PostMapping("/reserve")
+  @ResponseStatus(HttpStatus.CREATED)
+  public List<LectureEnrollmentReserveResponse> reserve(
+      @Valid @RequestBody LectureEnrollmentReserveRequest request) {
+    return enrollmentCommandService.reserve(request.toCommand()).stream()
+        .map(LectureEnrollmentReserveResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentReserveRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentReserveRequest.java
@@ -1,0 +1,18 @@
+package com.goggles.lecture_service.presentation.enrollment.internal.dto;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+public record LectureEnrollmentReserveRequest(
+    @NotEmpty(message = "productIds 는 비어있을 수 없습니다.") List<UUID> productIds,
+    @NotNull(message = "userId 는 필수입니다.") UUID userId,
+    @NotBlank(message = "userName 은 필수입니다.") String userName) {
+
+  public LectureEnrollmentReserveCommand toCommand() {
+    return new LectureEnrollmentReserveCommand(productIds, userId, userName);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentReserveResponse.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentReserveResponse.java
@@ -1,0 +1,23 @@
+package com.goggles.lecture_service.presentation.enrollment.internal.dto;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import java.util.UUID;
+
+public record LectureEnrollmentReserveResponse(
+    UUID enrollmentId,
+    UUID productId,
+    String productName,
+    Long productPrice,
+    UUID instructorId,
+    String instructorName) {
+
+  public static LectureEnrollmentReserveResponse from(LectureEnrollmentReserveResult result) {
+    return new LectureEnrollmentReserveResponse(
+        result.enrollmentId(),
+        result.productId(),
+        result.productName(),
+        result.productPrice(),
+        result.instructorId(),
+        result.instructorName());
+  }
+}

--- a/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
@@ -10,6 +10,7 @@ import com.goggles.lecture_service.application.enrollment.command.service.Enroll
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
 import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
@@ -63,6 +64,59 @@ class EnrollmentCommandServiceImplTest {
       assertThat(results).hasSize(1);
       assertThat(results.get(0).productId()).isEqualTo(lecture.getId());
       verify(enrollmentRepository).save(any(Enrollment.class));
+    }
+
+    @Test
+    @DisplayName("성공: 다건 강의 예약")
+    void reserve_multiProduct_success() {
+      Lecture lecture1 = publishedLecture();
+      Lecture lecture2 = publishedLecture();
+      List<UUID> productIds = List.of(lecture1.getId(), lecture2.getId());
+
+      when(lectureRepository.findAllByIdIn(productIds)).thenReturn(List.of(lecture1, lecture2));
+      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, lecture1.getId()))
+          .thenReturn(false);
+      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, lecture2.getId()))
+          .thenReturn(false);
+      when(enrollmentRepository.save(any(Enrollment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+      List<LectureEnrollmentReserveResult> results =
+          service.reserve(new LectureEnrollmentReserveCommand(productIds, userId, userName));
+
+      assertThat(results).hasSize(2);
+      assertThat(results)
+          .extracting(LectureEnrollmentReserveResult::productId)
+          .containsExactlyElementsOf(productIds);
+      verify(enrollmentRepository, times(2)).save(any(Enrollment.class));
+    }
+
+    @Test
+    @DisplayName("실패: productIds가 비어 있으면 예외")
+    void reserve_emptyProductIds_throws() {
+      assertThatThrownBy(() -> new LectureEnrollmentReserveCommand(List.of(), userId, userName))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 다건 중 일부 미출간이면 전체 예약 실패")
+    void reserve_partialNotPublished_allOrNothing() {
+      Lecture published = publishedLecture();
+      Lecture draft = draftLecture();
+      List<UUID> productIds = List.of(published.getId(), draft.getId());
+
+      when(lectureRepository.findAllByIdIn(productIds)).thenReturn(List.of(published, draft));
+      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, published.getId()))
+          .thenReturn(false);
+
+      assertThatThrownBy(
+              () ->
+                  service.reserve(
+                      new LectureEnrollmentReserveCommand(productIds, userId, userName)))
+          .isInstanceOf(EnrollmentReserveFailedException.class)
+          .extracting("reason")
+          .isEqualTo(ReserveFailReason.NOT_PUBLISHED);
+
+      verify(enrollmentRepository, never()).save(any(Enrollment.class));
     }
 
     @Test

--- a/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
@@ -1,0 +1,141 @@
+package com.goggles.lecture_service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandServiceImpl;
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EnrollmentCommandServiceImpl 테스트")
+class EnrollmentCommandServiceImplTest {
+
+  @Mock private LectureRepository lectureRepository;
+  @Mock private EnrollmentRepository enrollmentRepository;
+
+  @InjectMocks private EnrollmentCommandServiceImpl service;
+
+  private UUID userId;
+  private String userName;
+
+  @BeforeEach
+  void setUp() {
+    userId = UUID.randomUUID();
+    userName = "홍길동";
+  }
+
+  @Nested
+  @DisplayName("수강 등록 예약")
+  class Reserve {
+
+    @Test
+    @DisplayName("성공: 단건 강의 예약")
+    void reserve_singleProduct_success() {
+      Lecture lecture = publishedLecture();
+      when(lectureRepository.findAllByIdIn(List.of(lecture.getId()))).thenReturn(List.of(lecture));
+      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, lecture.getId()))
+          .thenReturn(false);
+      when(enrollmentRepository.save(any(Enrollment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+      List<LectureEnrollmentReserveResult> results =
+          service.reserve(
+              new LectureEnrollmentReserveCommand(List.of(lecture.getId()), userId, userName));
+
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).productId()).isEqualTo(lecture.getId());
+      verify(enrollmentRepository).save(any(Enrollment.class));
+    }
+
+    @Test
+    @DisplayName("실패: 강의 미존재")
+    void reserve_lectureNotFound_throws() {
+      UUID missing = UUID.randomUUID();
+      when(lectureRepository.findAllByIdIn(List.of(missing))).thenReturn(List.of());
+
+      assertThatThrownBy(
+              () ->
+                  service.reserve(
+                      new LectureEnrollmentReserveCommand(List.of(missing), userId, userName)))
+          .isInstanceOf(EnrollmentReserveFailedException.class)
+          .extracting("reason")
+          .isEqualTo(ReserveFailReason.LECTURE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패: 강의가 PUBLISHED 가 아닌 경우")
+    void reserve_notPublished_throws() {
+      Lecture draft = draftLecture(); // status = DRAFT
+      when(lectureRepository.findAllByIdIn(List.of(draft.getId()))).thenReturn(List.of(draft));
+
+      assertThatThrownBy(
+              () ->
+                  service.reserve(
+                      new LectureEnrollmentReserveCommand(
+                          List.of(draft.getId()), userId, userName)))
+          .isInstanceOf(EnrollmentReserveFailedException.class)
+          .extracting("reason")
+          .isEqualTo(ReserveFailReason.NOT_PUBLISHED);
+    }
+
+    @Test
+    @DisplayName("실패: 이미 수강 중인 강의")
+    void reserve_duplicate_throws() {
+      Lecture lecture = publishedLecture();
+      when(lectureRepository.findAllByIdIn(List.of(lecture.getId()))).thenReturn(List.of(lecture));
+      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, lecture.getId()))
+          .thenReturn(true);
+
+      assertThatThrownBy(
+              () ->
+                  service.reserve(
+                      new LectureEnrollmentReserveCommand(
+                          List.of(lecture.getId()), userId, userName)))
+          .isInstanceOf(EnrollmentReserveFailedException.class)
+          .extracting("reason")
+          .isEqualTo(ReserveFailReason.DUPLICATE_ENROLLMENT);
+    }
+  }
+
+  // --- 헬퍼: 테스트용 Lecture 생성 ---
+  private Lecture publishedLecture() {
+    Lecture l =
+        Lecture.create(
+            UUID.randomUUID(),
+            "강사명",
+            "BACKEND",
+            "스프링 강의",
+            "부제",
+            "설명",
+            DurationPolicy.DAYS_365,
+            10000L);
+    // 상태를 PUBLISHED 로 만들기 위해 도메인 메서드 시퀀스 호출
+    l.addChapter("챕터1", "내용", 1, 600);
+    l.submitForReview();
+    l.approve();
+    return l;
+  }
+
+  private Lecture draftLecture() {
+    return Lecture.create(
+        UUID.randomUUID(), "강사명", "BACKEND", "스프링 강의", "부제", "설명", DurationPolicy.DAYS_365, 10000L);
+  }
+}

--- a/src/test/java/com/goggles/lecture_service/EnrollmentTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentTest.java
@@ -60,7 +60,7 @@ class EnrollmentTest {
     @DisplayName("성공: RESERVE 상태로 생성된다")
     void reserve_success() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
 
       assertThat(enrollment).isNotNull();
       assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.RESERVE);
@@ -68,7 +68,7 @@ class EnrollmentTest {
       assertThat(enrollment.getInstructorId()).isEqualTo(instructorId);
       assertThat(enrollment.getLectureSnapshot().getLectureTitle()).isEqualTo("스프링 부트 입문");
       assertThat(enrollment.getStudentId()).isEqualTo(studentId);
-      assertThat(enrollment.getOrderId()).isEqualTo(orderId);
+      assertThat(enrollment.getOrderId()).isNull();
       assertThat(enrollment.getActivatedAt()).isNull();
       assertThat(enrollment.getExpiresAt()).isNull();
       assertThat(enrollment.getLastAccessedAt()).isNull();
@@ -77,31 +77,21 @@ class EnrollmentTest {
     @Test
     @DisplayName("실패: lectureSnapshot 이 null 이면 예외")
     void reserve_nullSnapshot_throws() {
-      assertThatThrownBy(
-              () -> Enrollment.reserve(null, studentId, orderId, DurationPolicy.DAYS_365))
+      assertThatThrownBy(() -> Enrollment.reserve(null, studentId, DurationPolicy.DAYS_365))
           .isInstanceOf(InvalidEnrollmentFieldException.class);
     }
 
     @Test
     @DisplayName("실패: studentId 가 null 이면 예외")
     void reserve_nullStudentId_throws() {
-      assertThatThrownBy(
-              () -> Enrollment.reserve(lectureSnapshot, null, orderId, DurationPolicy.DAYS_365))
-          .isInstanceOf(InvalidEnrollmentFieldException.class);
-    }
-
-    @Test
-    @DisplayName("실패: orderId 가 null 이면 예외")
-    void reserve_nullOrderId_throws() {
-      assertThatThrownBy(
-              () -> Enrollment.reserve(lectureSnapshot, studentId, null, DurationPolicy.DAYS_365))
+      assertThatThrownBy(() -> Enrollment.reserve(lectureSnapshot, null, DurationPolicy.DAYS_365))
           .isInstanceOf(InvalidEnrollmentFieldException.class);
     }
 
     @Test
     @DisplayName("실패: durationPolicy 가 null 이면 예외")
     void reserve_nullDurationPolicy_throws() {
-      assertThatThrownBy(() -> Enrollment.reserve(lectureSnapshot, studentId, orderId, null))
+      assertThatThrownBy(() -> Enrollment.reserve(lectureSnapshot, studentId, null))
           .isInstanceOf(InvalidEnrollmentFieldException.class);
     }
   }
@@ -111,26 +101,27 @@ class EnrollmentTest {
   class Activate {
 
     @Test
-    @DisplayName("성공: RESERVE → ACTIVE 전환되며 만료일이 설정된다")
+    @DisplayName("성공: RESERVE → ACTIVE 전환되며 만료일과 orderId 가 설정된다")
     void activate_success() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
       LocalDateTime now = LocalDateTime.now();
 
-      enrollment.activate(now);
+      enrollment.activate(now, orderId);
 
       assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.ACTIVE);
       assertThat(enrollment.getActivatedAt()).isEqualTo(now);
       assertThat(enrollment.getExpiresAt()).isEqualTo(now.plusDays(365));
+      assertThat(enrollment.getOrderId()).isEqualTo(orderId);
     }
 
     @Test
     @DisplayName("성공: UNLIMITED 정책이면 만료일이 9999년으로 설정된다")
     void activate_unlimited_setsFarFuture() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.UNLIMITED);
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.UNLIMITED);
 
-      enrollment.activate(LocalDateTime.now());
+      enrollment.activate(LocalDateTime.now(), orderId);
 
       assertThat(enrollment.getExpiresAt().getYear()).isEqualTo(9999);
     }
@@ -139,11 +130,21 @@ class EnrollmentTest {
     @DisplayName("실패: RESERVE 가 아닌 상태에서 activate 하면 예외")
     void activate_notReserveStatus_throws() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
       enrollment.cancel();
 
-      assertThatThrownBy(() -> enrollment.activate(LocalDateTime.now()))
+      assertThatThrownBy(() -> enrollment.activate(LocalDateTime.now(), orderId))
           .isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: activate 시 orderId 가 null 이면 예외")
+    void activate_nullOrderId_throws() {
+      Enrollment enrollment =
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
+
+      assertThatThrownBy(() -> enrollment.activate(LocalDateTime.now(), null))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
     }
   }
 
@@ -155,7 +156,7 @@ class EnrollmentTest {
     @DisplayName("성공: RESERVE 상태에서 취소 가능")
     void cancel_fromReserve_success() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
 
       enrollment.cancel();
 
@@ -166,8 +167,8 @@ class EnrollmentTest {
     @DisplayName("성공: ACTIVE 상태에서 취소 가능 (환불)")
     void cancel_fromActive_success() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
-      enrollment.activate(LocalDateTime.now());
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
+      enrollment.activate(LocalDateTime.now(), orderId);
 
       enrollment.cancel();
 
@@ -178,7 +179,7 @@ class EnrollmentTest {
     @DisplayName("실패: 이미 CANCELED 인 enrollment 는 다시 취소 불가")
     void cancel_alreadyCanceled_throws() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
       enrollment.cancel();
 
       assertThatThrownBy(enrollment::cancel).isInstanceOf(InvalidEnrollmentStatusException.class);
@@ -193,8 +194,8 @@ class EnrollmentTest {
     @DisplayName("성공: ACTIVE → EXPIRED 전환")
     void expire_fromActive_success() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
-      enrollment.activate(LocalDateTime.now());
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
+      enrollment.activate(LocalDateTime.now(), orderId);
 
       enrollment.expire();
 
@@ -205,7 +206,7 @@ class EnrollmentTest {
     @DisplayName("실패: RESERVE 상태에서 expire 호출 시 예외")
     void expire_fromReserve_throws() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
 
       assertThatThrownBy(enrollment::expire).isInstanceOf(InvalidEnrollmentStatusException.class);
     }
@@ -219,8 +220,8 @@ class EnrollmentTest {
     @DisplayName("성공: ACTIVE 상태에서 lastAccessedAt 갱신")
     void touch_fromActive_success() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
-      enrollment.activate(LocalDateTime.now());
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
+      enrollment.activate(LocalDateTime.now(), orderId);
       LocalDateTime accessTime = LocalDateTime.now();
 
       enrollment.touchLastAccessed(accessTime);
@@ -232,7 +233,7 @@ class EnrollmentTest {
     @DisplayName("실패: RESERVE 상태에서 호출 시 예외")
     void touch_fromReserve_throws() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
 
       assertThatThrownBy(() -> enrollment.touchLastAccessed(LocalDateTime.now()))
           .isInstanceOf(InvalidEnrollmentStatusException.class);
@@ -242,8 +243,8 @@ class EnrollmentTest {
     @DisplayName("실패: EXPIRED 상태에서 호출 시 예외")
     void touch_fromExpired_throws() {
       Enrollment enrollment =
-          Enrollment.reserve(lectureSnapshot, studentId, orderId, DurationPolicy.DAYS_365);
-      enrollment.activate(LocalDateTime.now());
+          Enrollment.reserve(lectureSnapshot, studentId, DurationPolicy.DAYS_365);
+      enrollment.activate(LocalDateTime.now(), orderId);
       enrollment.expire();
 
       assertThatThrownBy(() -> enrollment.touchLastAccessed(LocalDateTime.now()))


### PR DESCRIPTION
### 📌 관련 이슈
- close #16 
- 
### 💡 작업 내용
- Enrollment 도메인 구조 개선 (orderId 처리 방식 변경)
- 수강 등록 예약 API(reserve) 구현 진행(POST /internal/v1/lectures-enrollment/reserve)
- 강의 주문 가능 여부 검증 로직 추가 (isOrderable)

### 🔍 변경 이유
- 주문 서비스 v2 흐름에 맞게 reserve 시점에는 orderId 없이 처리하도록 수정
- order-service와의 동기 API 연동을 위한 기반 구조 구현

### 📝 리뷰 포인트 (선택)
- orderId를 activate 시점에 설정하는 방식이 적절한지 확인 부탁드립니다

### 🧠 기타 참고 사항
- 주문 서비스 v2 가이드 기반으로 설계 진행
- cancellation API는 별도 PR로 분리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 다중 강의 수강 예약 API 및 내부 엔드포인트 추가, 요청/응답 DTO와 예약 결과 반환
  * 강의 주문 가능 여부 확인과 일괄 강의 조회 지원
  * 예약 실패 사유(미존재·미공개·중복) 열거 및 전용 예외/오류코드 추가
  * 예약 흐름에서 예약 시 orderId를 선택적 처리하고 활성화 시 orderId를 필수화

* **Tests**
  * 수강 예약 서비스 동작 및 실패 시나리오 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->