### PR TITLE
[FEAT] 수강 등록 예약 취소 API 구현

### DIFF
--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentCancelCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentCancelCommand.java
@@ -3,5 +3,4 @@ package com.goggles.lecture_service.application.enrollment.command.dto;
 import java.util.List;
 import java.util.UUID;
 
-public record LectureEnrollmentCancelCommand(List<UUID> enrollmentIds, UUID userId) {
-}
+public record LectureEnrollmentCancelCommand(List<UUID> enrollmentIds, UUID userId) {}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentCancelCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentCancelCommand.java
@@ -1,6 +1,36 @@
 package com.goggles.lecture_service.application.enrollment.command.dto;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
-public record LectureEnrollmentCancelCommand(List<UUID> enrollmentIds, UUID userId) {}
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+
+public record LectureEnrollmentCancelCommand(List<UUID> enrollmentIds, UUID userId) {
+
+	public LectureEnrollmentCancelCommand {
+		if (enrollmentIds == null) {
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_IDS_REQUIRED);
+		}
+		if (enrollmentIds.isEmpty()) {
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_IDS_EMPTY);
+		}
+		if (enrollmentIds.stream().anyMatch(id -> id == null)) {
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_ID_REQUIRED);
+		}
+		if (new HashSet<>(enrollmentIds).size() != enrollmentIds.size()) {
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_IDS_DUPLICATED);
+		}
+		if (userId == null) {
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_USER_ID_REQUIRED);
+		}
+
+		enrollmentIds = List.copyOf(enrollmentIds);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentCancelCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentCancelCommand.java
@@ -1,36 +1,30 @@
 package com.goggles.lecture_service.application.enrollment.command.dto;
 
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
-import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
-import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
-
 public record LectureEnrollmentCancelCommand(List<UUID> enrollmentIds, UUID userId) {
 
-	public LectureEnrollmentCancelCommand {
-		if (enrollmentIds == null) {
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_IDS_REQUIRED);
-		}
-		if (enrollmentIds.isEmpty()) {
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_IDS_EMPTY);
-		}
-		if (enrollmentIds.stream().anyMatch(id -> id == null)) {
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_ID_REQUIRED);
-		}
-		if (new HashSet<>(enrollmentIds).size() != enrollmentIds.size()) {
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_IDS_DUPLICATED);
-		}
-		if (userId == null) {
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_USER_ID_REQUIRED);
-		}
+  public LectureEnrollmentCancelCommand {
+    if (enrollmentIds == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_IDS_REQUIRED);
+    }
+    if (enrollmentIds.isEmpty()) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_IDS_EMPTY);
+    }
+    if (enrollmentIds.stream().anyMatch(id -> id == null)) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ID_REQUIRED);
+    }
+    if (new HashSet<>(enrollmentIds).size() != enrollmentIds.size()) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_IDS_DUPLICATED);
+    }
+    if (userId == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_USER_ID_REQUIRED);
+    }
 
-		enrollmentIds = List.copyOf(enrollmentIds);
-	}
+    enrollmentIds = List.copyOf(enrollmentIds);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentCancelCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentCancelCommand.java
@@ -1,0 +1,7 @@
+package com.goggles.lecture_service.application.enrollment.command.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record LectureEnrollmentCancelCommand(List<UUID> enrollmentIds, UUID userId) {
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentReserveCommand.java
@@ -5,7 +5,7 @@ import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollment
 import java.util.List;
 import java.util.UUID;
 
-public record LectureEnrollmentReserveCommand(List<UUID> productIds, UUID userId, String userName) {
+public record LectureEnrollmentReserveCommand(List<UUID> productIds, UUID userId) {
 
   public LectureEnrollmentReserveCommand {
     if (productIds == null) {
@@ -17,9 +17,6 @@ public record LectureEnrollmentReserveCommand(List<UUID> productIds, UUID userId
     }
     if (userId == null) {
       throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_USER_ID_REQUIRED);
-    }
-    if (userName == null || userName.isBlank()) {
-      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_USER_NAME_REQUIRED);
     }
 
     productIds = List.copyOf(productIds);

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
@@ -1,14 +1,13 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
-import java.util.List;
-
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import java.util.List;
 
 public interface EnrollmentCommandService {
 
-	List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command);
+  List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command);
 
-	void cancel(LectureEnrollmentCancelCommand command);
+  void cancel(LectureEnrollmentCancelCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
@@ -1,10 +1,14 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
+import java.util.List;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
-import java.util.List;
 
 public interface EnrollmentCommandService {
 
-  List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command);
+	List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command);
+
+	void cancel(LectureEnrollmentCancelCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,5 +1,14 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
@@ -13,85 +22,84 @@ import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserve
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
-  private final LectureRepository lectureRepository;
-  private final EnrollmentRepository enrollmentRepository;
+	private final LectureRepository lectureRepository;
+	private final EnrollmentRepository enrollmentRepository;
 
-  @Override
-  public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
-    // 1) 강의 일괄 조회
-    List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
-    Map<UUID, Lecture> lectureMap =
-        lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+	@Override
+	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+		// 1) 강의 일괄 조회
+		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+		Map<UUID, Lecture> lectureMap =
+			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-    // 2) 전체 검증
-    for (UUID productId : command.productIds()) {
-      Lecture lecture = lectureMap.get(productId);
+		// 2) 전체 검증
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
 
-      if (lecture == null) {
-        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
-      }
+			if (lecture == null) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+			}
 
-      lecture.validateOrderable();
+			lecture.validateOrderable();
 
-      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
-        throw new EnrollmentReserveFailedException(
-            productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
-      }
-    }
-    // 3) 검증 통과 후 Enrollment 저장
-    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+				throw new EnrollmentReserveFailedException(
+					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+			}
+		}
+		// 3) 검증 통과 후 Enrollment 저장
+		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
-    for (UUID productId : command.productIds()) {
-      Lecture lecture = lectureMap.get(productId);
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
 
-      LectureSnapshot snapshot =
-          LectureSnapshot.of(
-              lecture.getId(),
-              lecture.getContent().getTitle(),
-              lecture.getInstructor().getInstructorId(),
-              lecture.getInstructor().getInstructorName());
+			LectureSnapshot snapshot =
+				LectureSnapshot.of(
+					lecture.getId(),
+					lecture.getContent().getTitle(),
+					lecture.getInstructor().getInstructorId(),
+					lecture.getInstructor().getInstructorName());
 
-      Enrollment enrollment =
-          Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+			Enrollment enrollment =
+				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
 
-      Enrollment saved = enrollmentRepository.save(enrollment);
+			Enrollment saved = enrollmentRepository.save(enrollment);
 
-      results.add(LectureEnrollmentReserveResult.of(saved, lecture));
-    }
+			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+		}
 
-    return results;
-  }
+		return results;
+	}
 
-  @Override
-  public void cancel(LectureEnrollmentCancelCommand command) {
-    // 1) Enrollment 일괄 조회
-    List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+	@Override
+	public void cancel(LectureEnrollmentCancelCommand command) {
+		List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
 
-    // 2) 모두 존재하는지 검증 (요청 개수 == 조회 개수)
-    if (enrollments.size() != command.enrollmentIds().size()) {
-      throw new EnrollmentNotFoundException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND);
-    }
+		Map<UUID, Enrollment> enrollmentMap =
+			enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
 
-    // 3) 본인 소유 검증 및 취서
-    for (Enrollment enrollment : enrollments) {
-      if (!enrollment.getStudentId().equals(command.userId())) {
-        throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
-      }
-      enrollment.cancel();
-    }
-  }
+		for (UUID enrollmentId : command.enrollmentIds()) {
+			Enrollment enrollment = enrollmentMap.get(enrollmentId);
+
+			if (enrollment == null) {
+				throw new EnrollmentNotFoundException(enrollmentId);
+			}
+
+			if (!enrollment.getStudentId().equals(command.userId())) {
+				throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
+			}
+		}
+
+		for (UUID enrollmentId : command.enrollmentIds()) {
+			enrollmentMap.get(enrollmentId).cancel();
+		}
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,14 +1,5 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
@@ -22,80 +13,85 @@ import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserve
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
-	private final LectureRepository lectureRepository;
-	private final EnrollmentRepository enrollmentRepository;
+  private final LectureRepository lectureRepository;
+  private final EnrollmentRepository enrollmentRepository;
 
-	@Override
-	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
-		// 1) 강의 일괄 조회
-		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
-		Map<UUID, Lecture> lectureMap =
-			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+  @Override
+  public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+    // 1) 강의 일괄 조회
+    List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+    Map<UUID, Lecture> lectureMap =
+        lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-		// 2) 전체 검증
-		for (UUID productId : command.productIds()) {
-			Lecture lecture = lectureMap.get(productId);
+    // 2) 전체 검증
+    for (UUID productId : command.productIds()) {
+      Lecture lecture = lectureMap.get(productId);
 
-			if (lecture == null) {
-				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
-			}
-			if (!lecture.isOrderable()) {
-				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
-			}
-			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
-				throw new EnrollmentReserveFailedException(
-					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
-			}
-		}
-		// 3) 검증 통과 후 Enrollment 저장
-		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+      if (lecture == null) {
+        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+      }
 
-		for (UUID productId : command.productIds()) {
-			Lecture lecture = lectureMap.get(productId);
+      lecture.validateOrderable();
 
-			LectureSnapshot snapshot =
-				LectureSnapshot.of(
-					lecture.getId(),
-					lecture.getContent().getTitle(),
-					lecture.getInstructor().getInstructorId(),
-					lecture.getInstructor().getInstructorName());
+      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+        throw new EnrollmentReserveFailedException(
+            productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+      }
+    }
+    // 3) 검증 통과 후 Enrollment 저장
+    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
-			Enrollment enrollment =
-				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+    for (UUID productId : command.productIds()) {
+      Lecture lecture = lectureMap.get(productId);
 
-			Enrollment saved = enrollmentRepository.save(enrollment);
+      LectureSnapshot snapshot =
+          LectureSnapshot.of(
+              lecture.getId(),
+              lecture.getContent().getTitle(),
+              lecture.getInstructor().getInstructorId(),
+              lecture.getInstructor().getInstructorName());
 
-			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
-		}
+      Enrollment enrollment =
+          Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
 
-		return results;
-	}
+      Enrollment saved = enrollmentRepository.save(enrollment);
 
-	@Override
-	public void cancel(LectureEnrollmentCancelCommand command) {
-		// 1) Enrollment 일괄 조회
-		List<Enrollment> enrollments =
-			enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+      results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+    }
 
-		// 2) 모두 존재하는지 검증 (요청 개수 == 조회 개수)
-		if (enrollments.size() != command.enrollmentIds().size()) {
-			throw new EnrollmentNotFoundException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND);
-		}
+    return results;
+  }
 
-		// 3) 본인 소유 검증 및 취서
-		for (Enrollment enrollment : enrollments) {
-			if (!enrollment.getStudentId().equals(command.userId())) {
-				throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
-			}
-			enrollment.cancel();
-		}
-	}
+  @Override
+  public void cancel(LectureEnrollmentCancelCommand command) {
+    // 1) Enrollment 일괄 조회
+    List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+
+    // 2) 모두 존재하는지 검증 (요청 개수 == 조회 개수)
+    if (enrollments.size() != command.enrollmentIds().size()) {
+      throw new EnrollmentNotFoundException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND);
+    }
+
+    // 3) 본인 소유 검증 및 취서
+    for (Enrollment enrollment : enrollments) {
+      if (!enrollment.getStudentId().equals(command.userId())) {
+        throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
+      }
+      enrollment.cancel();
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,5 +1,14 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
@@ -13,90 +22,86 @@ import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserve
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
-  private final LectureRepository lectureRepository;
-  private final EnrollmentRepository enrollmentRepository;
+	private final LectureRepository lectureRepository;
+	private final EnrollmentRepository enrollmentRepository;
 
-  @Override
-  public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
-    // 1) 강의 일괄 조회
-    List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
-    Map<UUID, Lecture> lectureMap =
-        lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+	@Override
+	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+		// 1) 강의 일괄 조회
+		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+		Map<UUID, Lecture> lectureMap =
+			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-    // 2) 전체 검증
-    for (UUID productId : command.productIds()) {
-      Lecture lecture = lectureMap.get(productId);
+		// 2) 전체 검증
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
 
-      if (lecture == null) {
-        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
-      }
+			if (lecture == null) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+			}
 
-      lecture.validateOrderable();
+			if (!lecture.isOrderable()) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
+			}
 
-      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
-        throw new EnrollmentReserveFailedException(
-            productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
-      }
-    }
-    // 3) 검증 통과 후 Enrollment 저장
-    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+				throw new EnrollmentReserveFailedException(
+					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+			}
+		}
+		// 3) 검증 통과 후 Enrollment 저장
+		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
-    for (UUID productId : command.productIds()) {
-      Lecture lecture = lectureMap.get(productId);
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
 
-      LectureSnapshot snapshot =
-          LectureSnapshot.of(
-              lecture.getId(),
-              lecture.getContent().getTitle(),
-              lecture.getInstructor().getInstructorId(),
-              lecture.getInstructor().getInstructorName());
+			LectureSnapshot snapshot =
+				LectureSnapshot.of(
+					lecture.getId(),
+					lecture.getContent().getTitle(),
+					lecture.getInstructor().getInstructorId(),
+					lecture.getInstructor().getInstructorName());
 
-      Enrollment enrollment =
-          Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+			Enrollment enrollment =
+				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
 
-      Enrollment saved = enrollmentRepository.save(enrollment);
+			Enrollment saved = enrollmentRepository.save(enrollment);
 
-      results.add(LectureEnrollmentReserveResult.of(saved, lecture));
-    }
+			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+		}
 
-    return results;
-  }
+		return results;
+	}
 
-  @Override
-  public void cancel(LectureEnrollmentCancelCommand command) {
-    List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+	@Override
+	public void cancel(LectureEnrollmentCancelCommand command) {
+		List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
 
-    Map<UUID, Enrollment> enrollmentMap =
-        enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
+		Map<UUID, Enrollment> enrollmentMap =
+			enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
 
-    for (UUID enrollmentId : command.enrollmentIds()) {
-      Enrollment enrollment = enrollmentMap.get(enrollmentId);
+		for (UUID enrollmentId : command.enrollmentIds()) {
+			Enrollment enrollment = enrollmentMap.get(enrollmentId);
 
-      if (enrollment == null) {
-        throw new EnrollmentNotFoundException(enrollmentId);
-      }
+			if (enrollment == null) {
+				throw new EnrollmentNotFoundException(enrollmentId);
+			}
 
-      if (!enrollment.getStudentId().equals(command.userId())) {
-        throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
-      }
-    }
+			if (!enrollment.getStudentId().equals(command.userId())) {
+				throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
+			}
+		}
 
-    for (UUID enrollmentId : command.enrollmentIds()) {
-      enrollmentMap.get(enrollmentId).cancel();
-    }
-  }
+		for (UUID enrollmentId : command.enrollmentIds()) {
+			enrollmentMap.get(enrollmentId).cancel();
+		}
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,74 +1,101 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
-import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
-import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
-import com.goggles.lecture_service.domain.enrollment.Enrollment;
-import com.goggles.lecture_service.domain.enrollment.LectureSnapshot;
-import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
-import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
-import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
-import com.goggles.lecture_service.domain.lecture.Lecture;
-import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.LectureSnapshot;
+import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentNotFoundException;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentNotOwnedException;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
-  private final LectureRepository lectureRepository;
-  private final EnrollmentRepository enrollmentRepository;
+	private final LectureRepository lectureRepository;
+	private final EnrollmentRepository enrollmentRepository;
 
-  @Override
-  public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
-    // 1) 강의 일괄 조회
-    List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
-    Map<UUID, Lecture> lectureMap =
-        lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+	@Override
+	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+		// 1) 강의 일괄 조회
+		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+		Map<UUID, Lecture> lectureMap =
+			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-    // 2) 전체 검증
-    for (UUID productId : command.productIds()) {
-      Lecture lecture = lectureMap.get(productId);
+		// 2) 전체 검증
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
 
-      if (lecture == null) {
-        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
-      }
-      if (!lecture.isOrderable()) {
-        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
-      }
-      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
-        throw new EnrollmentReserveFailedException(
-            productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
-      }
-    }
-    // 3) 검증 통과 후 Enrollment 저장
-    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+			if (lecture == null) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+			}
+			if (!lecture.isOrderable()) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
+			}
+			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+				throw new EnrollmentReserveFailedException(
+					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+			}
+		}
+		// 3) 검증 통과 후 Enrollment 저장
+		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
-    for (UUID productId : command.productIds()) {
-      Lecture lecture = lectureMap.get(productId);
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
 
-      LectureSnapshot snapshot =
-          LectureSnapshot.of(
-              lecture.getId(),
-              lecture.getContent().getTitle(),
-              lecture.getInstructor().getInstructorId(),
-              lecture.getInstructor().getInstructorName());
+			LectureSnapshot snapshot =
+				LectureSnapshot.of(
+					lecture.getId(),
+					lecture.getContent().getTitle(),
+					lecture.getInstructor().getInstructorId(),
+					lecture.getInstructor().getInstructorName());
 
-      Enrollment enrollment =
-          Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+			Enrollment enrollment =
+				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
 
-      Enrollment saved = enrollmentRepository.save(enrollment);
+			Enrollment saved = enrollmentRepository.save(enrollment);
 
-      results.add(LectureEnrollmentReserveResult.of(saved, lecture));
-    }
+			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+		}
 
-    return results;
-  }
+		return results;
+	}
+
+	@Override
+	public void cancel(LectureEnrollmentCancelCommand command) {
+		// 1) Enrollment 일괄 조회
+		List<Enrollment> enrollments =
+			enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+
+		// 2) 모두 존재하는지 검증 (요청 개수 == 조회 개수)
+		if (enrollments.size() != command.enrollmentIds().size()) {
+			throw new EnrollmentNotFoundException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND);
+		}
+
+		// 3) 본인 소유 검증 및 취서
+		for (Enrollment enrollment : enrollments) {
+			if (!enrollment.getStudentId().equals(command.userId())) {
+				throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
+			}
+			enrollment.cancel();
+		}
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,14 +1,5 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
@@ -22,84 +13,90 @@ import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserve
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
-	private final LectureRepository lectureRepository;
-	private final EnrollmentRepository enrollmentRepository;
+  private final LectureRepository lectureRepository;
+  private final EnrollmentRepository enrollmentRepository;
 
-	@Override
-	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
-		// 1) 강의 일괄 조회
-		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
-		Map<UUID, Lecture> lectureMap =
-			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+  @Override
+  public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+    // 1) 강의 일괄 조회
+    List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+    Map<UUID, Lecture> lectureMap =
+        lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-		// 2) 전체 검증
-		for (UUID productId : command.productIds()) {
-			Lecture lecture = lectureMap.get(productId);
+    // 2) 전체 검증
+    for (UUID productId : command.productIds()) {
+      Lecture lecture = lectureMap.get(productId);
 
-			if (lecture == null) {
-				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
-			}
+      if (lecture == null) {
+        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+      }
 
-			lecture.validateOrderable();
+      lecture.validateOrderable();
 
-			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
-				throw new EnrollmentReserveFailedException(
-					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
-			}
-		}
-		// 3) 검증 통과 후 Enrollment 저장
-		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+        throw new EnrollmentReserveFailedException(
+            productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+      }
+    }
+    // 3) 검증 통과 후 Enrollment 저장
+    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
-		for (UUID productId : command.productIds()) {
-			Lecture lecture = lectureMap.get(productId);
+    for (UUID productId : command.productIds()) {
+      Lecture lecture = lectureMap.get(productId);
 
-			LectureSnapshot snapshot =
-				LectureSnapshot.of(
-					lecture.getId(),
-					lecture.getContent().getTitle(),
-					lecture.getInstructor().getInstructorId(),
-					lecture.getInstructor().getInstructorName());
+      LectureSnapshot snapshot =
+          LectureSnapshot.of(
+              lecture.getId(),
+              lecture.getContent().getTitle(),
+              lecture.getInstructor().getInstructorId(),
+              lecture.getInstructor().getInstructorName());
 
-			Enrollment enrollment =
-				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+      Enrollment enrollment =
+          Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
 
-			Enrollment saved = enrollmentRepository.save(enrollment);
+      Enrollment saved = enrollmentRepository.save(enrollment);
 
-			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
-		}
+      results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+    }
 
-		return results;
-	}
+    return results;
+  }
 
-	@Override
-	public void cancel(LectureEnrollmentCancelCommand command) {
-		List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+  @Override
+  public void cancel(LectureEnrollmentCancelCommand command) {
+    List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
 
-		Map<UUID, Enrollment> enrollmentMap =
-			enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
+    Map<UUID, Enrollment> enrollmentMap =
+        enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
 
-		for (UUID enrollmentId : command.enrollmentIds()) {
-			Enrollment enrollment = enrollmentMap.get(enrollmentId);
+    for (UUID enrollmentId : command.enrollmentIds()) {
+      Enrollment enrollment = enrollmentMap.get(enrollmentId);
 
-			if (enrollment == null) {
-				throw new EnrollmentNotFoundException(enrollmentId);
-			}
+      if (enrollment == null) {
+        throw new EnrollmentNotFoundException(enrollmentId);
+      }
 
-			if (!enrollment.getStudentId().equals(command.userId())) {
-				throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
-			}
-		}
+      if (!enrollment.getStudentId().equals(command.userId())) {
+        throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
+      }
+    }
 
-		for (UUID enrollmentId : command.enrollmentIds()) {
-			enrollmentMap.get(enrollmentId).cancel();
-		}
-	}
+    for (UUID enrollmentId : command.enrollmentIds()) {
+      enrollmentMap.get(enrollmentId).cancel();
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
@@ -1,11 +1,17 @@
 package com.goggles.lecture_service.domain.enrollment;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.SQLRestriction;
+
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
 import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
 import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
 import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentStatusException;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -14,161 +20,176 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(
-    name = "p_enrollment",
-    indexes = {
-      @Index(name = "idx_enrollment_student_status", columnList = "student_id, status"),
-      @Index(name = "idx_enrollment_order_id", columnList = "order_id")
-    })
+	name = "p_enrollment",
+	indexes = {
+		@Index(name = "idx_enrollment_student_status", columnList = "student_id, status"),
+		@Index(name = "idx_enrollment_order_id", columnList = "order_id")
+	})
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Enrollment extends BaseAudit {
 
-  @Id
-  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
-  private UUID id = UUID.randomUUID();
+	@Id
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id = UUID.randomUUID();
 
-  // 강의 스냅샷 (lectureId + lectureTitle + instructorId + instructorName)
-  @Embedded private LectureSnapshot lectureSnapshot;
+	// 강의 스냅샷 (lectureId + lectureTitle + instructorId + instructorName)
+	@Embedded
+	private LectureSnapshot lectureSnapshot;
 
-  @Column(name = "student_id", nullable = false)
-  private UUID studentId;
+	@Column(name = "student_id", nullable = false)
+	private UUID studentId;
 
-  @Column(name = "order_id")
-  private UUID orderId;
+	@Column(name = "order_id")
+	private UUID orderId;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private EnrollmentStatus status;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private EnrollmentStatus status;
 
-  @Enumerated(EnumType.STRING)
-  @Column(name = "duration_policy", nullable = false, length = 20)
-  private DurationPolicy durationPolicy;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "duration_policy", nullable = false, length = 20)
+	private DurationPolicy durationPolicy;
 
-  @Column(name = "activated_at")
-  private LocalDateTime activatedAt;
+	@Column(name = "activated_at")
+	private LocalDateTime activatedAt;
 
-  @Column(name = "expires_at")
-  private LocalDateTime expiresAt;
+	@Column(name = "expires_at")
+	private LocalDateTime expiresAt;
 
-  @Column(name = "last_accessed_at")
-  private LocalDateTime lastAccessedAt; // ← 추가
+	@Column(name = "last_accessed_at")
+	private LocalDateTime lastAccessedAt; // ← 추가
 
-  // 정적 팩토리 메서드: RESERVE 로 생성
-  public static Enrollment reserve(
-      LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
-    validateRequired(lectureSnapshot, studentId, durationPolicy);
-    return new Enrollment(lectureSnapshot, studentId, durationPolicy);
-  }
+	// 정적 팩토리 메서드: RESERVE 로 생성
+	public static Enrollment reserve(
+		LectureSnapshot snapshot,
+		UUID studentId,
+		DurationPolicy durationPolicy) {
 
-  private Enrollment(
-      LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
-    this.lectureSnapshot = lectureSnapshot;
-    this.studentId = studentId;
-    this.durationPolicy = durationPolicy;
-    this.status = EnrollmentStatus.RESERVE;
-  }
+		if (snapshot == null) {
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
+		}
 
-  // 도메인 메서드 (상태 전이)
-  public void activate(LocalDateTime now, UUID orderId) {
-    validateNow(now);
-    validateOrderId(orderId);
-    if (this.status != EnrollmentStatus.RESERVE) {
-      throw new InvalidEnrollmentStatusException(
-          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE);
-    }
-    this.activatedAt = now;
-    this.orderId = orderId;
-    this.expiresAt = calculateExpiresAt(now, this.durationPolicy);
-    this.status = EnrollmentStatus.ACTIVE;
-  }
+		if (studentId == null) {
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
+		}
 
-  public void cancel() {
-    if (this.status != EnrollmentStatus.RESERVE && this.status != EnrollmentStatus.ACTIVE) {
-      throw new InvalidEnrollmentStatusException(
-          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_CANCEL);
-    }
-    this.status = EnrollmentStatus.CANCELED;
-  }
+		if (durationPolicy == null) {
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
+		}
 
-  public void expire() {
-    if (this.status != EnrollmentStatus.ACTIVE) {
-      throw new InvalidEnrollmentStatusException(
-          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_EXPIRE);
-    }
-    this.status = EnrollmentStatus.EXPIRED;
-  }
+		return new Enrollment(snapshot, studentId, durationPolicy, EnrollmentStatus.RESERVE);
+	}
 
-  // 사용자가 강의에 접근할 때 호출 (마지막 수강 시각 갱신)
-  public void touchLastAccessed(LocalDateTime now) {
-    validateNow(now);
-    if (this.status != EnrollmentStatus.ACTIVE) {
-      throw new InvalidEnrollmentStatusException(
-          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACCESS);
-    }
-    this.lastAccessedAt = now;
-  }
+	private Enrollment(
+		LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
+		this.lectureSnapshot = lectureSnapshot;
+		this.studentId = studentId;
+		this.durationPolicy = durationPolicy;
+		this.status = EnrollmentStatus.RESERVE;
+	}
 
-  // 편의 메서드
+	// 도메인 메서드 (상태 전이)
+	public void activate(LocalDateTime now, UUID orderId) {
+		validateNow(now);
+		validateOrderId(orderId);
+		if (this.status != EnrollmentStatus.RESERVE) {
+			throw new InvalidEnrollmentStatusException(
+				EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE);
+		}
+		this.activatedAt = now;
+		this.orderId = orderId;
+		this.expiresAt = calculateExpiresAt(now, this.durationPolicy);
+		this.status = EnrollmentStatus.ACTIVE;
+	}
 
-  public boolean isActive() {
-    return this.status == EnrollmentStatus.ACTIVE;
-  }
+	public void cancel() {
+		if (this.status != EnrollmentStatus.RESERVE && this.status != EnrollmentStatus.ACTIVE) {
+			throw new InvalidEnrollmentStatusException(
+				EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_CANCEL);
+		}
+		this.status = EnrollmentStatus.CANCELED;
+	}
 
-  public boolean isExpired(LocalDateTime now) {
-    validateNow(now);
-    return this.expiresAt != null && now.isAfter(this.expiresAt);
-  }
+	public void expire() {
+		if (this.status != EnrollmentStatus.ACTIVE) {
+			throw new InvalidEnrollmentStatusException(
+				EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_EXPIRE);
+		}
+		this.status = EnrollmentStatus.EXPIRED;
+	}
 
-  // 스냅샷 내부 직접 접근
-  public UUID getLectureId() {
-    return this.lectureSnapshot.getLectureId();
-  }
+	// 사용자가 강의에 접근할 때 호출 (마지막 수강 시각 갱신)
+	public void touchLastAccessed(LocalDateTime now) {
+		validateNow(now);
+		if (this.status != EnrollmentStatus.ACTIVE) {
+			throw new InvalidEnrollmentStatusException(
+				EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACCESS);
+		}
+		this.lastAccessedAt = now;
+	}
 
-  public UUID getInstructorId() {
-    return this.lectureSnapshot.getInstructorId();
-  }
+	// 편의 메서드
 
-  // 내부 검증
-  private static void validateRequired(
-      LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
-    if (lectureSnapshot == null)
-      throw new InvalidEnrollmentFieldException(
-          EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
-    if (studentId == null)
-      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
-    if (durationPolicy == null)
-      throw new InvalidEnrollmentFieldException(
-          EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
-  }
+	public boolean isActive() {
+		return this.status == EnrollmentStatus.ACTIVE;
+	}
 
-  private static void validateOrderId(UUID orderId) {
-    if (orderId == null) {
-      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ORDER_ID_REQUIRED);
-    }
-  }
+	public boolean isExpired(LocalDateTime now) {
+		validateNow(now);
+		return this.expiresAt != null && now.isAfter(this.expiresAt);
+	}
 
-  private static void validateNow(LocalDateTime now) {
-    if (now == null) {
-      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_TIME_REQUIRED);
-    }
-  }
+	// 스냅샷 내부 직접 접근
+	public UUID getLectureId() {
+		return this.lectureSnapshot.getLectureId();
+	}
 
-  private static LocalDateTime calculateExpiresAt(LocalDateTime from, DurationPolicy policy) {
-    return switch (policy) {
-      case DAYS_90 -> from.plusDays(90);
-      case DAYS_180 -> from.plusDays(180);
-      case DAYS_365 -> from.plusDays(365);
-      case UNLIMITED -> LocalDateTime.of(9999, 12, 31, 23, 59, 59);
-    };
-  }
+	public UUID getInstructorId() {
+		return this.lectureSnapshot.getInstructorId();
+	}
+
+	// 내부 검증
+	private static void validateRequired(
+		LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
+		if (lectureSnapshot == null)
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
+		if (studentId == null)
+			throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
+		if (durationPolicy == null)
+			throw new InvalidEnrollmentFieldException(
+				EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
+	}
+
+	private static void validateOrderId(UUID orderId) {
+		if (orderId == null) {
+			throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ORDER_ID_REQUIRED);
+		}
+	}
+
+	private static void validateNow(LocalDateTime now) {
+		if (now == null) {
+			throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_TIME_REQUIRED);
+		}
+	}
+
+	private static LocalDateTime calculateExpiresAt(LocalDateTime from, DurationPolicy policy) {
+		return switch (policy) {
+			case DAYS_90 -> from.plusDays(90);
+			case DAYS_180 -> from.plusDays(180);
+			case DAYS_365 -> from.plusDays(365);
+			case UNLIMITED -> LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+		};
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
@@ -1,17 +1,11 @@
 package com.goggles.lecture_service.domain.enrollment;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-import org.hibernate.annotations.SQLRestriction;
-
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
 import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
 import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
 import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentStatusException;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -20,176 +14,174 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(
-	name = "p_enrollment",
-	indexes = {
-		@Index(name = "idx_enrollment_student_status", columnList = "student_id, status"),
-		@Index(name = "idx_enrollment_order_id", columnList = "order_id")
-	})
+    name = "p_enrollment",
+    indexes = {
+      @Index(name = "idx_enrollment_student_status", columnList = "student_id, status"),
+      @Index(name = "idx_enrollment_order_id", columnList = "order_id")
+    })
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Enrollment extends BaseAudit {
 
-	@Id
-	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
-	private UUID id = UUID.randomUUID();
+  @Id
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id = UUID.randomUUID();
 
-	// 강의 스냅샷 (lectureId + lectureTitle + instructorId + instructorName)
-	@Embedded
-	private LectureSnapshot lectureSnapshot;
+  // 강의 스냅샷 (lectureId + lectureTitle + instructorId + instructorName)
+  @Embedded private LectureSnapshot lectureSnapshot;
 
-	@Column(name = "student_id", nullable = false)
-	private UUID studentId;
+  @Column(name = "student_id", nullable = false)
+  private UUID studentId;
 
-	@Column(name = "order_id")
-	private UUID orderId;
+  @Column(name = "order_id")
+  private UUID orderId;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private EnrollmentStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private EnrollmentStatus status;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "duration_policy", nullable = false, length = 20)
-	private DurationPolicy durationPolicy;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "duration_policy", nullable = false, length = 20)
+  private DurationPolicy durationPolicy;
 
-	@Column(name = "activated_at")
-	private LocalDateTime activatedAt;
+  @Column(name = "activated_at")
+  private LocalDateTime activatedAt;
 
-	@Column(name = "expires_at")
-	private LocalDateTime expiresAt;
+  @Column(name = "expires_at")
+  private LocalDateTime expiresAt;
 
-	@Column(name = "last_accessed_at")
-	private LocalDateTime lastAccessedAt; // ← 추가
+  @Column(name = "last_accessed_at")
+  private LocalDateTime lastAccessedAt; // ← 추가
 
-	// 정적 팩토리 메서드: RESERVE 로 생성
-	public static Enrollment reserve(
-		LectureSnapshot snapshot,
-		UUID studentId,
-		DurationPolicy durationPolicy) {
+  // 정적 팩토리 메서드: RESERVE 로 생성
+  public static Enrollment reserve(
+      LectureSnapshot snapshot, UUID studentId, DurationPolicy durationPolicy) {
 
-		if (snapshot == null) {
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
-		}
+    if (snapshot == null) {
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
+    }
 
-		if (studentId == null) {
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
-		}
+    if (studentId == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
+    }
 
-		if (durationPolicy == null) {
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
-		}
+    if (durationPolicy == null) {
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
+    }
 
-		return new Enrollment(snapshot, studentId, durationPolicy, EnrollmentStatus.RESERVE);
-	}
+    return new Enrollment(snapshot, studentId, durationPolicy);
+  }
 
-	private Enrollment(
-		LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
-		this.lectureSnapshot = lectureSnapshot;
-		this.studentId = studentId;
-		this.durationPolicy = durationPolicy;
-		this.status = EnrollmentStatus.RESERVE;
-	}
+  private Enrollment(
+      LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
+    this.lectureSnapshot = lectureSnapshot;
+    this.studentId = studentId;
+    this.durationPolicy = durationPolicy;
+    this.status = EnrollmentStatus.RESERVE;
+  }
 
-	// 도메인 메서드 (상태 전이)
-	public void activate(LocalDateTime now, UUID orderId) {
-		validateNow(now);
-		validateOrderId(orderId);
-		if (this.status != EnrollmentStatus.RESERVE) {
-			throw new InvalidEnrollmentStatusException(
-				EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE);
-		}
-		this.activatedAt = now;
-		this.orderId = orderId;
-		this.expiresAt = calculateExpiresAt(now, this.durationPolicy);
-		this.status = EnrollmentStatus.ACTIVE;
-	}
+  // 도메인 메서드 (상태 전이)
+  public void activate(LocalDateTime now, UUID orderId) {
+    validateNow(now);
+    validateOrderId(orderId);
+    if (this.status != EnrollmentStatus.RESERVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE);
+    }
+    this.activatedAt = now;
+    this.orderId = orderId;
+    this.expiresAt = calculateExpiresAt(now, this.durationPolicy);
+    this.status = EnrollmentStatus.ACTIVE;
+  }
 
-	public void cancel() {
-		if (this.status != EnrollmentStatus.RESERVE && this.status != EnrollmentStatus.ACTIVE) {
-			throw new InvalidEnrollmentStatusException(
-				EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_CANCEL);
-		}
-		this.status = EnrollmentStatus.CANCELED;
-	}
+  public void cancel() {
+    if (this.status != EnrollmentStatus.RESERVE && this.status != EnrollmentStatus.ACTIVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_CANCEL);
+    }
+    this.status = EnrollmentStatus.CANCELED;
+  }
 
-	public void expire() {
-		if (this.status != EnrollmentStatus.ACTIVE) {
-			throw new InvalidEnrollmentStatusException(
-				EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_EXPIRE);
-		}
-		this.status = EnrollmentStatus.EXPIRED;
-	}
+  public void expire() {
+    if (this.status != EnrollmentStatus.ACTIVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_EXPIRE);
+    }
+    this.status = EnrollmentStatus.EXPIRED;
+  }
 
-	// 사용자가 강의에 접근할 때 호출 (마지막 수강 시각 갱신)
-	public void touchLastAccessed(LocalDateTime now) {
-		validateNow(now);
-		if (this.status != EnrollmentStatus.ACTIVE) {
-			throw new InvalidEnrollmentStatusException(
-				EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACCESS);
-		}
-		this.lastAccessedAt = now;
-	}
+  // 사용자가 강의에 접근할 때 호출 (마지막 수강 시각 갱신)
+  public void touchLastAccessed(LocalDateTime now) {
+    validateNow(now);
+    if (this.status != EnrollmentStatus.ACTIVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ACCESS);
+    }
+    this.lastAccessedAt = now;
+  }
 
-	// 편의 메서드
+  // 편의 메서드
+  public boolean isActive() {
+    return this.status == EnrollmentStatus.ACTIVE;
+  }
 
-	public boolean isActive() {
-		return this.status == EnrollmentStatus.ACTIVE;
-	}
+  public boolean isExpired(LocalDateTime now) {
+    validateNow(now);
+    return this.expiresAt != null && now.isAfter(this.expiresAt);
+  }
 
-	public boolean isExpired(LocalDateTime now) {
-		validateNow(now);
-		return this.expiresAt != null && now.isAfter(this.expiresAt);
-	}
+  // 스냅샷 내부 직접 접근
+  public UUID getLectureId() {
+    return this.lectureSnapshot.getLectureId();
+  }
 
-	// 스냅샷 내부 직접 접근
-	public UUID getLectureId() {
-		return this.lectureSnapshot.getLectureId();
-	}
+  public UUID getInstructorId() {
+    return this.lectureSnapshot.getInstructorId();
+  }
 
-	public UUID getInstructorId() {
-		return this.lectureSnapshot.getInstructorId();
-	}
+  // 내부 검증
+  private static void validateRequired(
+      LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
+    if (lectureSnapshot == null)
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
+    if (studentId == null)
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
+    if (durationPolicy == null)
+      throw new InvalidEnrollmentFieldException(
+          EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
+  }
 
-	// 내부 검증
-	private static void validateRequired(
-		LectureSnapshot lectureSnapshot, UUID studentId, DurationPolicy durationPolicy) {
-		if (lectureSnapshot == null)
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED);
-		if (studentId == null)
-			throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_STUDENT_ID_REQUIRED);
-		if (durationPolicy == null)
-			throw new InvalidEnrollmentFieldException(
-				EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
-	}
+  private static void validateOrderId(UUID orderId) {
+    if (orderId == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ORDER_ID_REQUIRED);
+    }
+  }
 
-	private static void validateOrderId(UUID orderId) {
-		if (orderId == null) {
-			throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ORDER_ID_REQUIRED);
-		}
-	}
+  private static void validateNow(LocalDateTime now) {
+    if (now == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_TIME_REQUIRED);
+    }
+  }
 
-	private static void validateNow(LocalDateTime now) {
-		if (now == null) {
-			throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_TIME_REQUIRED);
-		}
-	}
-
-	private static LocalDateTime calculateExpiresAt(LocalDateTime from, DurationPolicy policy) {
-		return switch (policy) {
-			case DAYS_90 -> from.plusDays(90);
-			case DAYS_180 -> from.plusDays(180);
-			case DAYS_365 -> from.plusDays(365);
-			case UNLIMITED -> LocalDateTime.of(9999, 12, 31, 23, 59, 59);
-		};
-	}
+  private static LocalDateTime calculateExpiresAt(LocalDateTime from, DurationPolicy policy) {
+    return switch (policy) {
+      case DAYS_90 -> from.plusDays(90);
+      case DAYS_180 -> from.plusDays(180);
+      case DAYS_365 -> from.plusDays(365);
+      case UNLIMITED -> LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+    };
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -7,42 +7,42 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EnrollmentErrorCode {
 
-	// 조회
-	ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
+  // 조회
+  ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
 
-	// 중복
-	ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
+  // 중복
+  ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
 
-	// 상태 전이
-	ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
-	ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
-	ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
-	ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
+  // 상태 전이
+  ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
 
-	// 강의 검증
-	ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
-	ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
-	ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
-	ENROLLMENT_NOT_OWNED("본인 소유의 수강 정보가 아닙니다."),
+  // 강의 검증
+  ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
+  ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
+  ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
+  ENROLLMENT_NOT_OWNED("본인 소유의 수강 정보가 아닙니다."),
 
-	// 필수 필드 - 스냅샷
-	ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
-	ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
-	ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
-	ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
-	ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+  // 필수 필드 - 스냅샷
+  ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
+  ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+  ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
+  ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+  ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
 
-	// 필수 필드 - 기타
-	ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
-	ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
-	ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
-	ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
+  // 필수 필드 - 기타
+  ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
+  ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
+  ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
+  ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
 
-	// 요청 필드 검증
-	ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
-	ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
-	ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
-	ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
+  // 요청 필드 검증
+  ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
+  ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
+  ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+  ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
 
-	private final String message;
+  private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -7,46 +7,46 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EnrollmentErrorCode {
 
-	// 조회
-	ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
+  // 조회
+  ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
 
-	// 중복
-	ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
+  // 중복
+  ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
 
-	// 상태 전이
-	ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
-	ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
-	ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
-	ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
+  // 상태 전이
+  ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
 
-	// 강의 검증
-	ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
-	ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
-	ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
+  // 강의 검증
+  ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
+  ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
+  ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
   ENROLLMENT_NOT_OWNED("본인 소유의 수강 정보가 아닙니다."),
 
-	// 필수 필드 - 스냅샷
-	ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
-	ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
-	ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
-	ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
-	ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+  // 필수 필드 - 스냅샷
+  ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
+  ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+  ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
+  ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+  ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
 
-	// 필수 필드 - 기타
-	ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
-	ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
-	ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
-	ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
+  // 필수 필드 - 기타
+  ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
+  ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
+  ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
+  ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
 
-	// 요청 필드 검증
-	ENROLLMENT_IDS_REQUIRED("수강 ID 목록은 필수입니다."),
-	ENROLLMENT_IDS_EMPTY("수강 ID 목록은 비어 있을 수 없습니다."),
-	ENROLLMENT_ID_REQUIRED("수강 ID는 필수입니다."),
-	ENROLLMENT_IDS_DUPLICATED("수강 ID 목록에 중복 값이 있을 수 없습니다."),
-	ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
-	ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
-	ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
-	ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
+  // 요청 필드 검증
+  ENROLLMENT_IDS_REQUIRED("수강 ID 목록은 필수입니다."),
+  ENROLLMENT_IDS_EMPTY("수강 ID 목록은 비어 있을 수 없습니다."),
+  ENROLLMENT_ID_REQUIRED("수강 ID는 필수입니다."),
+  ENROLLMENT_IDS_DUPLICATED("수강 ID 목록에 중복 값이 있을 수 없습니다."),
+  ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
+  ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
+  ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+  ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
 
-	private final String message;
+  private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -7,42 +7,46 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EnrollmentErrorCode {
 
-  // 조회
-  ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
+	// 조회
+	ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
 
-  // 중복
-  ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
+	// 중복
+	ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
 
-  // 상태 전이
-  ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
-  ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
-  ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
-  ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
+	// 상태 전이
+	ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
+	ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
+	ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
+	ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
 
-  // 강의 검증
-  ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
-  ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
-  ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
+	// 강의 검증
+	ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
+	ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
+	ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
   ENROLLMENT_NOT_OWNED("본인 소유의 수강 정보가 아닙니다."),
 
-  // 필수 필드 - 스냅샷
-  ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
-  ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
-  ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
-  ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
-  ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+	// 필수 필드 - 스냅샷
+	ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
+	ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+	ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
+	ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+	ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
 
-  // 필수 필드 - 기타
-  ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
-  ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
-  ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
-  ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
+	// 필수 필드 - 기타
+	ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
+	ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
+	ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
+	ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
 
-  // 요청 필드 검증
-  ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
-  ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
-  ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
-  ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
+	// 요청 필드 검증
+	ENROLLMENT_IDS_REQUIRED("수강 ID 목록은 필수입니다."),
+	ENROLLMENT_IDS_EMPTY("수강 ID 목록은 비어 있을 수 없습니다."),
+	ENROLLMENT_ID_REQUIRED("수강 ID는 필수입니다."),
+	ENROLLMENT_IDS_DUPLICATED("수강 ID 목록에 중복 값이 있을 수 없습니다."),
+	ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
+	ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
+	ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+	ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
 
-  private final String message;
+	private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -7,41 +7,42 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EnrollmentErrorCode {
 
-  // 조회
-  ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
+	// 조회
+	ENROLLMENT_NOT_FOUND("해당 수강 정보를 찾을 수 없습니다."),
 
-  // 중복
-  ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
+	// 중복
+	ENROLLMENT_DUPLICATE("이미 수강 중인 강의입니다."),
 
-  // 상태 전이
-  ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
-  ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
-  ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
-  ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
+	// 상태 전이
+	ENROLLMENT_INVALID_STATUS_FOR_ACTIVATE("RESERVE 상태에서만 활성화할 수 있습니다."),
+	ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
+	ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
+	ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
 
-  // 강의 검증
-  ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
-  ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
-  ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
+	// 강의 검증
+	ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),
+	ENROLLMENT_LECTURE_DELETED("삭제된 강의입니다."),
+	ENROLLMENT_RESERVE_FAILED("수강 등록 예약에 실패했습니다."),
+	ENROLLMENT_NOT_OWNED("본인 소유의 수강 정보가 아닙니다."),
 
-  // 필수 필드 - 스냅샷
-  ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
-  ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
-  ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
-  ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
-  ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+	// 필수 필드 - 스냅샷
+	ENROLLMENT_LECTURE_SNAPSHOT_REQUIRED("강의 스냅샷은 필수입니다."),
+	ENROLLMENT_LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+	ENROLLMENT_LECTURE_TITLE_REQUIRED("강의명은 필수입니다."),
+	ENROLLMENT_INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+	ENROLLMENT_INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
 
-  // 필수 필드 - 기타
-  ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
-  ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
-  ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
-  ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
+	// 필수 필드 - 기타
+	ENROLLMENT_STUDENT_ID_REQUIRED("학생 ID는 필수입니다."),
+	ENROLLMENT_ORDER_ID_REQUIRED("주문 ID는 필수입니다."),
+	ENROLLMENT_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
+	ENROLLMENT_TIME_REQUIRED("시간 정보는 필수입니다."),
 
-  // 요청 필드 검증
-  ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
-  ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
-  ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
-  ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
+	// 요청 필드 검증
+	ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
+	ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
+	ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+	ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
 
-  private final String message;
+	private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
@@ -1,9 +1,12 @@
 package com.goggles.lecture_service.domain.enrollment.exception;
 
-import com.goggles.common.exception.BadRequestException;
+import java.util.UUID;
 
-public class EnrollmentNotFoundException extends BadRequestException {
-  public EnrollmentNotFoundException(EnrollmentErrorCode errorCode) {
-    super(errorCode.getMessage());
-  }
+import com.goggles.common.exception.NotFoundException;
+
+public class EnrollmentNotFoundException extends NotFoundException {
+
+	public EnrollmentNotFoundException(UUID id) {
+		super(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND.getMessage() + " id=" + id);
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
@@ -3,7 +3,7 @@ package com.goggles.lecture_service.domain.enrollment.exception;
 import com.goggles.common.exception.BadRequestException;
 
 public class EnrollmentNotFoundException extends BadRequestException {
-	public EnrollmentNotFoundException(EnrollmentErrorCode errorCode) {
-		super(errorCode.getMessage());
-	}
+  public EnrollmentNotFoundException(EnrollmentErrorCode errorCode) {
+    super(errorCode.getMessage());
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
@@ -1,12 +1,11 @@
 package com.goggles.lecture_service.domain.enrollment.exception;
 
-import java.util.UUID;
-
 import com.goggles.common.exception.NotFoundException;
+import java.util.UUID;
 
 public class EnrollmentNotFoundException extends NotFoundException {
 
-	public EnrollmentNotFoundException(UUID id) {
-		super(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND.getMessage() + " id=" + id);
-	}
+  public EnrollmentNotFoundException(UUID id) {
+    super(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND.getMessage() + " id=" + id);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotFoundException.java
@@ -1,10 +1,9 @@
 package com.goggles.lecture_service.domain.enrollment.exception;
 
-import com.goggles.common.exception.NotFoundException;
-import java.util.UUID;
+import com.goggles.common.exception.BadRequestException;
 
-public class EnrollmentNotFoundException extends NotFoundException {
-  public EnrollmentNotFoundException(UUID id) {
-    super(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND.getMessage() + " id=" + id);
-  }
+public class EnrollmentNotFoundException extends BadRequestException {
+	public EnrollmentNotFoundException(EnrollmentErrorCode errorCode) {
+		super(errorCode.getMessage());
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotOwnedException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotOwnedException.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.domain.enrollment.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class EnrollmentNotOwnedException extends BadRequestException {
+
+	public EnrollmentNotOwnedException(EnrollmentErrorCode errorCode) {
+		super(errorCode.getMessage());
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotOwnedException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentNotOwnedException.java
@@ -4,7 +4,7 @@ import com.goggles.common.exception.BadRequestException;
 
 public class EnrollmentNotOwnedException extends BadRequestException {
 
-	public EnrollmentNotOwnedException(EnrollmentErrorCode errorCode) {
-		super(errorCode.getMessage());
-	}
+  public EnrollmentNotOwnedException(EnrollmentErrorCode errorCode) {
+    super(errorCode.getMessage());
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,23 +1,26 @@
 package com.goggles.lecture_service.domain.enrollment.repository;
 
-import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+
 public interface EnrollmentRepository {
 
-  Enrollment save(Enrollment enrollment);
+	Enrollment save(Enrollment enrollment);
 
-  Optional<Enrollment> findById(UUID id);
+	Optional<Enrollment> findById(UUID id);
 
-  Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId);
+	List<Enrollment> findAllByIdIn(List<UUID> ids);
 
-  // 동일 학생 + 동일 강의에 RESERVE/ACTIVE 인 enrollment 존재 여부. 중복 수강 검증용
-  boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId);
+	Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId);
 
-  List<Enrollment> findAllByOrderId(UUID orderId);
+	// 동일 학생 + 동일 강의에 RESERVE/ACTIVE 인 enrollment 존재 여부. 중복 수강 검증용
+	boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId);
 
-  // 학생의 ACTIVE 한 enrollment(내 강의 화면)
-  List<Enrollment> findActiveByStudentId(UUID studentId);
+	List<Enrollment> findAllByOrderId(UUID orderId);
+
+	// 학생의 ACTIVE 한 enrollment(내 강의 화면)
+	List<Enrollment> findActiveByStudentId(UUID studentId);
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,26 +1,25 @@
 package com.goggles.lecture_service.domain.enrollment.repository;
 
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.goggles.lecture_service.domain.enrollment.Enrollment;
-
 public interface EnrollmentRepository {
 
-	Enrollment save(Enrollment enrollment);
+  Enrollment save(Enrollment enrollment);
 
-	Optional<Enrollment> findById(UUID id);
+  Optional<Enrollment> findById(UUID id);
 
-	List<Enrollment> findAllByIdIn(List<UUID> ids);
+  List<Enrollment> findAllByIdIn(List<UUID> ids);
 
-	Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId);
+  Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId);
 
-	// 동일 학생 + 동일 강의에 RESERVE/ACTIVE 인 enrollment 존재 여부. 중복 수강 검증용
-	boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId);
+  // 동일 학생 + 동일 강의에 RESERVE/ACTIVE 인 enrollment 존재 여부. 중복 수강 검증용
+  boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId);
 
-	List<Enrollment> findAllByOrderId(UUID orderId);
+  List<Enrollment> findAllByOrderId(UUID orderId);
 
-	// 학생의 ACTIVE 한 enrollment(내 강의 화면)
-	List<Enrollment> findActiveByStudentId(UUID studentId);
+  // 학생의 ACTIVE 한 enrollment(내 강의 화면)
+  List<Enrollment> findActiveByStudentId(UUID studentId);
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,6 +1,15 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.SQLRestriction;
+
 import com.goggles.common.domain.BaseAudit;
+import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.exception.ChapterNotFoundException;
@@ -10,6 +19,7 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldE
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -19,14 +29,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -35,192 +40,204 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-  @Id
-  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
-  private UUID id = UUID.randomUUID();
+	@Id
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id = UUID.randomUUID();
 
-  @Embedded private Instructor instructor;
+	@Embedded
+	private Instructor instructor;
 
-  @Column(nullable = false, length = 50)
-  private String category;
+	@Column(nullable = false, length = 50)
+	private String category;
 
-  @Embedded private LectureContent content;
+	@Embedded
+	private LectureContent content;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private DurationPolicy durationPolicy;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private DurationPolicy durationPolicy;
 
-  @Embedded private Money price;
+	@Embedded
+	private Money price;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private LectureStatus status;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private LectureStatus status;
 
-  @Column(columnDefinition = "TEXT")
-  private String rejectionReason;
+	@Column(columnDefinition = "TEXT")
+	private String rejectionReason;
 
-  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Chapter> chapters = new ArrayList<>();
+	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Chapter> chapters = new ArrayList<>();
 
-  // 정적 팩토리 메서드
+	// 정적 팩토리 메서드
 
-  public static Lecture create(
-      UUID instructorId,
-      String instructorName,
-      String category,
-      String title,
-      String subtitle,
-      String description,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
+	public static Lecture create(
+		UUID instructorId,
+		String instructorName,
+		String category,
+		String title,
+		String subtitle,
+		String description,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
 
-    validateCategory(category);
+		validateCategory(category);
 
-    return new Lecture(
-        new Instructor(instructorId, instructorName),
-        category,
-        new LectureContent(title, subtitle, description),
-        durationPolicy,
-        Money.of(priceAmount));
-  }
+		return new Lecture(
+			new Instructor(instructorId, instructorName),
+			category,
+			new LectureContent(title, subtitle, description),
+			durationPolicy,
+			Money.of(priceAmount));
+	}
 
-  private Lecture(
-      Instructor instructor,
-      String category,
-      LectureContent content,
-      DurationPolicy durationPolicy,
-      Money price) {
-    this.instructor = instructor;
-    this.category = category;
-    this.content = content;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = price;
-    this.status = LectureStatus.DRAFT;
-  }
+	private Lecture(
+		Instructor instructor,
+		String category,
+		LectureContent content,
+		DurationPolicy durationPolicy,
+		Money price) {
+		this.instructor = instructor;
+		this.category = category;
+		this.content = content;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = price;
+		this.status = LectureStatus.DRAFT;
+	}
 
-  // 도메인 메서드 (챕터 관리)
+	// 도메인 메서드 (챕터 관리)
 
-  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
-    validateDraftStatus();
-    validateDuplicateSortOrder(sortOrder);
+	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
+		validateDraftStatus();
+		validateDuplicateSortOrder(sortOrder);
 
-    ChapterContent chapterContent = new ChapterContent(title, content);
-    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+		ChapterContent chapterContent = new ChapterContent(title, content);
+		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-    chapters.add(chapter);
+		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+		chapters.add(chapter);
 
-    return chapter.getId();
-  }
+		return chapter.getId();
+	}
 
-  public void removeChapter(UUID chapterId) {
-    validateDraftStatus();
-    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-    if (!removed) {
-      throw new ChapterNotFoundException(chapterId);
-    }
-  }
+	public void removeChapter(UUID chapterId) {
+		validateDraftStatus();
+		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+		if (!removed) {
+			throw new ChapterNotFoundException(chapterId);
+		}
+	}
 
-  public void reorderChapter(UUID chapterId, int newSortOrder) {
-    validateDraftStatus();
-    Chapter target = findChapterById(chapterId);
-    if (target.getSortOrder() == newSortOrder) return;
-    validateDuplicateSortOrder(newSortOrder);
-    target.updateSortOrder(newSortOrder);
-  }
+	public void reorderChapter(UUID chapterId, int newSortOrder) {
+		validateDraftStatus();
+		Chapter target = findChapterById(chapterId);
+		if (target.getSortOrder() == newSortOrder)
+			return;
+		validateDuplicateSortOrder(newSortOrder);
+		target.updateSortOrder(newSortOrder);
+	}
 
-  public List<Chapter> getChapters() {
-    return Collections.unmodifiableList(chapters);
-  }
+	public List<Chapter> getChapters() {
+		return Collections.unmodifiableList(chapters);
+	}
 
-  // 도메인 메서드 (정보 수정)
+	// 도메인 메서드 (정보 수정)
 
-  public void updateMetadata(
-      String title,
-      String subtitle,
-      String description,
-      String category,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
-    validateDraftStatus();
-    validateCategory(category);
+	public void updateMetadata(
+		String title,
+		String subtitle,
+		String description,
+		String category,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
+		validateDraftStatus();
+		validateCategory(category);
 
-    this.content = new LectureContent(title, subtitle, description);
-    this.category = category;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = Money.of(priceAmount);
-  }
+		this.content = new LectureContent(title, subtitle, description);
+		this.category = category;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = Money.of(priceAmount);
+	}
 
-  // 도메인 메서드 (상태 전이)
+	// 도메인 메서드 (상태 전이)
 
-  public void submitForReview() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    if (chapters.isEmpty()) {
-      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-    }
-    this.status = LectureStatus.PENDING_REVIEW;
-    // 리뷰 재신청 시 이전 이유 삭제
-    this.rejectionReason = null;
-  }
+	public void submitForReview() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (chapters.isEmpty()) {
+			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
+		}
+		this.status = LectureStatus.PENDING_REVIEW;
+		// 리뷰 재신청 시 이전 이유 삭제
+		this.rejectionReason = null;
+	}
 
-  public void approve() {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    this.status = LectureStatus.PUBLISHED;
-    this.rejectionReason = null;
-  }
+	public void approve() {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.PUBLISHED;
+		this.rejectionReason = null;
+	}
 
-  public void reject(String reason) {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    if (reason == null || reason.isBlank()) {
-      throw new InvalidRejectionReasonException();
-    }
-    this.status = LectureStatus.DRAFT;
-    this.rejectionReason = reason;
-  }
+	public void reject(String reason) {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (reason == null || reason.isBlank()) {
+			throw new InvalidRejectionReasonException();
+		}
+		this.status = LectureStatus.DRAFT;
+		this.rejectionReason = reason;
+	}
 
-  public void hide() {
-    if (this.status != LectureStatus.PUBLISHED) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    this.status = LectureStatus.HIDDEN;
-  }
+	public void hide() {
+		if (this.status != LectureStatus.PUBLISHED) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.HIDDEN;
+	}
 
-  // 주문 가능 여부
-  public boolean isOrderable() {
-    return this.status == LectureStatus.PUBLISHED;
-  }
+	// 주문 가능 여부
+	public boolean isOrderable() {
+		return this.status == LectureStatus.PUBLISHED;
+	}
 
-  // 내부 검증 및 편의 메서드
+	// 내부 검증 및 편의 메서드
 
-  private void validateDraftStatus() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-  }
+	private void validateDraftStatus() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+	}
 
-  private void validateDuplicateSortOrder(int sortOrder) {
-    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-    if (isDuplicate) {
-      throw new DuplicateSortOrderException(sortOrder);
-    }
-  }
+	private void validateDuplicateSortOrder(int sortOrder) {
+		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+		if (isDuplicate) {
+			throw new DuplicateSortOrderException(sortOrder);
+		}
+	}
 
-  private Chapter findChapterById(UUID chapterId) {
-    return chapters.stream()
-        .filter(c -> c.getId().equals(chapterId))
-        .findFirst()
-        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
-  }
+	private Chapter findChapterById(UUID chapterId) {
+		return chapters.stream()
+			.filter(c -> c.getId().equals(chapterId))
+			.findFirst()
+			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
+	}
 
-  private static void validateCategory(String category) {
-    if (category == null || category.isBlank()) {
-      throw new InvalidCategoryException();
-    }
-  }
+	private static void validateCategory(String category) {
+		if (category == null || category.isBlank()) {
+			throw new InvalidCategoryException();
+		}
+	}
+
+	public void validateOrderable() {
+		if (!isOrderable()) {
+			throw new EnrollmentReserveFailedException(
+				this.getId(), ReserveFailReason.NOT_PUBLISHED);
+		}
+	}
+
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,12 +1,5 @@
 package com.goggles.lecture_service.domain.lecture;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import org.hibernate.annotations.SQLRestriction;
-
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
 import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
@@ -19,7 +12,6 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldE
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -29,9 +21,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -40,204 +37,198 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-	@Id
-	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
-	private UUID id = UUID.randomUUID();
+  @Id
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id = UUID.randomUUID();
 
-	@Embedded
-	private Instructor instructor;
+  @Embedded private Instructor instructor;
 
-	@Column(nullable = false, length = 50)
-	private String category;
+  @Column(nullable = false, length = 50)
+  private String category;
 
-	@Embedded
-	private LectureContent content;
+  @Embedded private LectureContent content;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private DurationPolicy durationPolicy;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private DurationPolicy durationPolicy;
 
-	@Embedded
-	private Money price;
+  @Embedded private Money price;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private LectureStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private LectureStatus status;
 
-	@Column(columnDefinition = "TEXT")
-	private String rejectionReason;
+  @Column(columnDefinition = "TEXT")
+  private String rejectionReason;
 
-	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Chapter> chapters = new ArrayList<>();
+  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Chapter> chapters = new ArrayList<>();
 
-	// 정적 팩토리 메서드
+  // 정적 팩토리 메서드
 
-	public static Lecture create(
-		UUID instructorId,
-		String instructorName,
-		String category,
-		String title,
-		String subtitle,
-		String description,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
+  public static Lecture create(
+      UUID instructorId,
+      String instructorName,
+      String category,
+      String title,
+      String subtitle,
+      String description,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
 
-		validateCategory(category);
+    validateCategory(category);
 
-		return new Lecture(
-			new Instructor(instructorId, instructorName),
-			category,
-			new LectureContent(title, subtitle, description),
-			durationPolicy,
-			Money.of(priceAmount));
-	}
+    return new Lecture(
+        new Instructor(instructorId, instructorName),
+        category,
+        new LectureContent(title, subtitle, description),
+        durationPolicy,
+        Money.of(priceAmount));
+  }
 
-	private Lecture(
-		Instructor instructor,
-		String category,
-		LectureContent content,
-		DurationPolicy durationPolicy,
-		Money price) {
-		this.instructor = instructor;
-		this.category = category;
-		this.content = content;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = price;
-		this.status = LectureStatus.DRAFT;
-	}
+  private Lecture(
+      Instructor instructor,
+      String category,
+      LectureContent content,
+      DurationPolicy durationPolicy,
+      Money price) {
+    this.instructor = instructor;
+    this.category = category;
+    this.content = content;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = price;
+    this.status = LectureStatus.DRAFT;
+  }
 
-	// 도메인 메서드 (챕터 관리)
+  // 도메인 메서드 (챕터 관리)
 
-	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
-		validateDraftStatus();
-		validateDuplicateSortOrder(sortOrder);
+  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
+    validateDraftStatus();
+    validateDuplicateSortOrder(sortOrder);
 
-		ChapterContent chapterContent = new ChapterContent(title, content);
-		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+    ChapterContent chapterContent = new ChapterContent(title, content);
+    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-		chapters.add(chapter);
+    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+    chapters.add(chapter);
 
-		return chapter.getId();
-	}
+    return chapter.getId();
+  }
 
-	public void removeChapter(UUID chapterId) {
-		validateDraftStatus();
-		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-		if (!removed) {
-			throw new ChapterNotFoundException(chapterId);
-		}
-	}
+  public void removeChapter(UUID chapterId) {
+    validateDraftStatus();
+    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+    if (!removed) {
+      throw new ChapterNotFoundException(chapterId);
+    }
+  }
 
-	public void reorderChapter(UUID chapterId, int newSortOrder) {
-		validateDraftStatus();
-		Chapter target = findChapterById(chapterId);
-		if (target.getSortOrder() == newSortOrder)
-			return;
-		validateDuplicateSortOrder(newSortOrder);
-		target.updateSortOrder(newSortOrder);
-	}
+  public void reorderChapter(UUID chapterId, int newSortOrder) {
+    validateDraftStatus();
+    Chapter target = findChapterById(chapterId);
+    if (target.getSortOrder() == newSortOrder) return;
+    validateDuplicateSortOrder(newSortOrder);
+    target.updateSortOrder(newSortOrder);
+  }
 
-	public List<Chapter> getChapters() {
-		return Collections.unmodifiableList(chapters);
-	}
+  public List<Chapter> getChapters() {
+    return Collections.unmodifiableList(chapters);
+  }
 
-	// 도메인 메서드 (정보 수정)
+  // 도메인 메서드 (정보 수정)
 
-	public void updateMetadata(
-		String title,
-		String subtitle,
-		String description,
-		String category,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
-		validateDraftStatus();
-		validateCategory(category);
+  public void updateMetadata(
+      String title,
+      String subtitle,
+      String description,
+      String category,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
+    validateDraftStatus();
+    validateCategory(category);
 
-		this.content = new LectureContent(title, subtitle, description);
-		this.category = category;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = Money.of(priceAmount);
-	}
+    this.content = new LectureContent(title, subtitle, description);
+    this.category = category;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = Money.of(priceAmount);
+  }
 
-	// 도메인 메서드 (상태 전이)
+  // 도메인 메서드 (상태 전이)
 
-	public void submitForReview() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (chapters.isEmpty()) {
-			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-		}
-		this.status = LectureStatus.PENDING_REVIEW;
-		// 리뷰 재신청 시 이전 이유 삭제
-		this.rejectionReason = null;
-	}
+  public void submitForReview() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (chapters.isEmpty()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
+    }
+    this.status = LectureStatus.PENDING_REVIEW;
+    // 리뷰 재신청 시 이전 이유 삭제
+    this.rejectionReason = null;
+  }
 
-	public void approve() {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.PUBLISHED;
-		this.rejectionReason = null;
-	}
+  public void approve() {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.PUBLISHED;
+    this.rejectionReason = null;
+  }
 
-	public void reject(String reason) {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (reason == null || reason.isBlank()) {
-			throw new InvalidRejectionReasonException();
-		}
-		this.status = LectureStatus.DRAFT;
-		this.rejectionReason = reason;
-	}
+  public void reject(String reason) {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new InvalidRejectionReasonException();
+    }
+    this.status = LectureStatus.DRAFT;
+    this.rejectionReason = reason;
+  }
 
-	public void hide() {
-		if (this.status != LectureStatus.PUBLISHED) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.HIDDEN;
-	}
+  public void hide() {
+    if (this.status != LectureStatus.PUBLISHED) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.HIDDEN;
+  }
 
-	// 주문 가능 여부
-	public boolean isOrderable() {
-		return this.status == LectureStatus.PUBLISHED;
-	}
+  // 주문 가능 여부
+  public boolean isOrderable() {
+    return this.status == LectureStatus.PUBLISHED;
+  }
 
-	// 내부 검증 및 편의 메서드
+  // 내부 검증 및 편의 메서드
 
-	private void validateDraftStatus() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-	}
+  private void validateDraftStatus() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+  }
 
-	private void validateDuplicateSortOrder(int sortOrder) {
-		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-		if (isDuplicate) {
-			throw new DuplicateSortOrderException(sortOrder);
-		}
-	}
+  private void validateDuplicateSortOrder(int sortOrder) {
+    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+    if (isDuplicate) {
+      throw new DuplicateSortOrderException(sortOrder);
+    }
+  }
 
-	private Chapter findChapterById(UUID chapterId) {
-		return chapters.stream()
-			.filter(c -> c.getId().equals(chapterId))
-			.findFirst()
-			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
-	}
+  private Chapter findChapterById(UUID chapterId) {
+    return chapters.stream()
+        .filter(c -> c.getId().equals(chapterId))
+        .findFirst()
+        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
+  }
 
-	private static void validateCategory(String category) {
-		if (category == null || category.isBlank()) {
-			throw new InvalidCategoryException();
-		}
-	}
+  private static void validateCategory(String category) {
+    if (category == null || category.isBlank()) {
+      throw new InvalidCategoryException();
+    }
+  }
 
-	public void validateOrderable() {
-		if (!isOrderable()) {
-			throw new EnrollmentReserveFailedException(
-				this.getId(), ReserveFailReason.NOT_PUBLISHED);
-		}
-	}
-
+  public void validateOrderable() {
+    if (!isOrderable()) {
+      throw new EnrollmentReserveFailedException(this.getId(), ReserveFailReason.NOT_PUBLISHED);
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,8 +1,13 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.SQLRestriction;
+
 import com.goggles.common.domain.BaseAudit;
-import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
-import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.exception.ChapterNotFoundException;
@@ -12,6 +17,7 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldE
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -21,14 +27,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -37,198 +38,196 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-  @Id
-  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
-  private UUID id = UUID.randomUUID();
+	@Id
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id = UUID.randomUUID();
 
-  @Embedded private Instructor instructor;
+	@Embedded
+	private Instructor instructor;
 
-  @Column(nullable = false, length = 50)
-  private String category;
+	@Column(nullable = false, length = 50)
+	private String category;
 
-  @Embedded private LectureContent content;
+	@Embedded
+	private LectureContent content;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private DurationPolicy durationPolicy;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private DurationPolicy durationPolicy;
 
-  @Embedded private Money price;
+	@Embedded
+	private Money price;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private LectureStatus status;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private LectureStatus status;
 
-  @Column(columnDefinition = "TEXT")
-  private String rejectionReason;
+	@Column(columnDefinition = "TEXT")
+	private String rejectionReason;
 
-  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Chapter> chapters = new ArrayList<>();
+	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Chapter> chapters = new ArrayList<>();
 
-  // 정적 팩토리 메서드
+	// 정적 팩토리 메서드
 
-  public static Lecture create(
-      UUID instructorId,
-      String instructorName,
-      String category,
-      String title,
-      String subtitle,
-      String description,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
+	public static Lecture create(
+		UUID instructorId,
+		String instructorName,
+		String category,
+		String title,
+		String subtitle,
+		String description,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
 
-    validateCategory(category);
+		validateCategory(category);
 
-    return new Lecture(
-        new Instructor(instructorId, instructorName),
-        category,
-        new LectureContent(title, subtitle, description),
-        durationPolicy,
-        Money.of(priceAmount));
-  }
+		return new Lecture(
+			new Instructor(instructorId, instructorName),
+			category,
+			new LectureContent(title, subtitle, description),
+			durationPolicy,
+			Money.of(priceAmount));
+	}
 
-  private Lecture(
-      Instructor instructor,
-      String category,
-      LectureContent content,
-      DurationPolicy durationPolicy,
-      Money price) {
-    this.instructor = instructor;
-    this.category = category;
-    this.content = content;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = price;
-    this.status = LectureStatus.DRAFT;
-  }
+	private Lecture(
+		Instructor instructor,
+		String category,
+		LectureContent content,
+		DurationPolicy durationPolicy,
+		Money price) {
+		this.instructor = instructor;
+		this.category = category;
+		this.content = content;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = price;
+		this.status = LectureStatus.DRAFT;
+	}
 
-  // 도메인 메서드 (챕터 관리)
+	// 도메인 메서드 (챕터 관리)
 
-  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
-    validateDraftStatus();
-    validateDuplicateSortOrder(sortOrder);
+	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
+		validateDraftStatus();
+		validateDuplicateSortOrder(sortOrder);
 
-    ChapterContent chapterContent = new ChapterContent(title, content);
-    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+		ChapterContent chapterContent = new ChapterContent(title, content);
+		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-    chapters.add(chapter);
+		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+		chapters.add(chapter);
 
-    return chapter.getId();
-  }
+		return chapter.getId();
+	}
 
-  public void removeChapter(UUID chapterId) {
-    validateDraftStatus();
-    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-    if (!removed) {
-      throw new ChapterNotFoundException(chapterId);
-    }
-  }
+	public void removeChapter(UUID chapterId) {
+		validateDraftStatus();
+		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+		if (!removed) {
+			throw new ChapterNotFoundException(chapterId);
+		}
+	}
 
-  public void reorderChapter(UUID chapterId, int newSortOrder) {
-    validateDraftStatus();
-    Chapter target = findChapterById(chapterId);
-    if (target.getSortOrder() == newSortOrder) return;
-    validateDuplicateSortOrder(newSortOrder);
-    target.updateSortOrder(newSortOrder);
-  }
+	public void reorderChapter(UUID chapterId, int newSortOrder) {
+		validateDraftStatus();
+		Chapter target = findChapterById(chapterId);
+		if (target.getSortOrder() == newSortOrder)
+			return;
+		validateDuplicateSortOrder(newSortOrder);
+		target.updateSortOrder(newSortOrder);
+	}
 
-  public List<Chapter> getChapters() {
-    return Collections.unmodifiableList(chapters);
-  }
+	public List<Chapter> getChapters() {
+		return Collections.unmodifiableList(chapters);
+	}
 
-  // 도메인 메서드 (정보 수정)
+	// 도메인 메서드 (정보 수정)
 
-  public void updateMetadata(
-      String title,
-      String subtitle,
-      String description,
-      String category,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
-    validateDraftStatus();
-    validateCategory(category);
+	public void updateMetadata(
+		String title,
+		String subtitle,
+		String description,
+		String category,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
+		validateDraftStatus();
+		validateCategory(category);
 
-    this.content = new LectureContent(title, subtitle, description);
-    this.category = category;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = Money.of(priceAmount);
-  }
+		this.content = new LectureContent(title, subtitle, description);
+		this.category = category;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = Money.of(priceAmount);
+	}
 
-  // 도메인 메서드 (상태 전이)
+	// 도메인 메서드 (상태 전이)
 
-  public void submitForReview() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    if (chapters.isEmpty()) {
-      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-    }
-    this.status = LectureStatus.PENDING_REVIEW;
-    // 리뷰 재신청 시 이전 이유 삭제
-    this.rejectionReason = null;
-  }
+	public void submitForReview() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (chapters.isEmpty()) {
+			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
+		}
+		this.status = LectureStatus.PENDING_REVIEW;
+		// 리뷰 재신청 시 이전 이유 삭제
+		this.rejectionReason = null;
+	}
 
-  public void approve() {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    this.status = LectureStatus.PUBLISHED;
-    this.rejectionReason = null;
-  }
+	public void approve() {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.PUBLISHED;
+		this.rejectionReason = null;
+	}
 
-  public void reject(String reason) {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    if (reason == null || reason.isBlank()) {
-      throw new InvalidRejectionReasonException();
-    }
-    this.status = LectureStatus.DRAFT;
-    this.rejectionReason = reason;
-  }
+	public void reject(String reason) {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (reason == null || reason.isBlank()) {
+			throw new InvalidRejectionReasonException();
+		}
+		this.status = LectureStatus.DRAFT;
+		this.rejectionReason = reason;
+	}
 
-  public void hide() {
-    if (this.status != LectureStatus.PUBLISHED) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    this.status = LectureStatus.HIDDEN;
-  }
+	public void hide() {
+		if (this.status != LectureStatus.PUBLISHED) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.HIDDEN;
+	}
 
-  // 주문 가능 여부
-  public boolean isOrderable() {
-    return this.status == LectureStatus.PUBLISHED;
-  }
+	// 주문 가능 여부
+	public boolean isOrderable() {
+		return this.status == LectureStatus.PUBLISHED;
+	}
 
-  // 내부 검증 및 편의 메서드
+	// 내부 검증 및 편의 메서드
 
-  private void validateDraftStatus() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-  }
+	private void validateDraftStatus() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+	}
 
-  private void validateDuplicateSortOrder(int sortOrder) {
-    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-    if (isDuplicate) {
-      throw new DuplicateSortOrderException(sortOrder);
-    }
-  }
+	private void validateDuplicateSortOrder(int sortOrder) {
+		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+		if (isDuplicate) {
+			throw new DuplicateSortOrderException(sortOrder);
+		}
+	}
 
-  private Chapter findChapterById(UUID chapterId) {
-    return chapters.stream()
-        .filter(c -> c.getId().equals(chapterId))
-        .findFirst()
-        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
-  }
+	private Chapter findChapterById(UUID chapterId) {
+		return chapters.stream()
+			.filter(c -> c.getId().equals(chapterId))
+			.findFirst()
+			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
+	}
 
-  private static void validateCategory(String category) {
-    if (category == null || category.isBlank()) {
-      throw new InvalidCategoryException();
-    }
-  }
-
-  public void validateOrderable() {
-    if (!isOrderable()) {
-      throw new EnrollmentReserveFailedException(this.getId(), ReserveFailReason.NOT_PUBLISHED);
-    }
-  }
+	private static void validateCategory(String category) {
+		if (category == null || category.isBlank()) {
+			throw new InvalidCategoryException();
+		}
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
@@ -1,38 +1,42 @@
 package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
-import com.goggles.lecture_service.domain.enrollment.Enrollment;
-import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+
 public interface EnrollmentJpaRepository extends JpaRepository<Enrollment, UUID> {
 
-  @Query(
-      "select e from Enrollment e "
-          + "where e.orderId = :orderId "
-          + "and e.lectureSnapshot.lectureId = :lectureId")
-  Optional<Enrollment> findByOrderIdAndLectureId(
-      @Param("orderId") UUID orderId, @Param("lectureId") UUID lectureId);
+	@Query(
+		"select e from Enrollment e "
+			+ "where e.orderId = :orderId "
+			+ "and e.lectureSnapshot.lectureId = :lectureId")
+	Optional<Enrollment> findByOrderIdAndLectureId(
+		@Param("orderId") UUID orderId, @Param("lectureId") UUID lectureId);
 
-  @Query(
-      "select count(e) > 0 from Enrollment e "
-          + "where e.studentId = :studentId "
-          + "and e.lectureSnapshot.lectureId = :lectureId "
-          + "and e.status in :statuses")
-  boolean existsByStudentAndLectureAndStatusIn(
-      @Param("studentId") UUID studentId,
-      @Param("lectureId") UUID lectureId,
-      @Param("statuses") Collection<EnrollmentStatus> statuses);
+	@Query(
+		"select count(e) > 0 from Enrollment e "
+			+ "where e.studentId = :studentId "
+			+ "and e.lectureSnapshot.lectureId = :lectureId "
+			+ "and e.status in :statuses")
+	boolean existsByStudentAndLectureAndStatusIn(
+		@Param("studentId") UUID studentId,
+		@Param("lectureId") UUID lectureId,
+		@Param("statuses") Collection<EnrollmentStatus> statuses);
 
-  List<Enrollment> findAllByOrderId(UUID orderId);
+	List<Enrollment> findAllByOrderId(UUID orderId);
 
-  @Query(
-      "select e from Enrollment e " + "where e.studentId = :studentId " + "and e.status = :status")
-  List<Enrollment> findByStudentIdAndStatus(
-      @Param("studentId") UUID studentId, @Param("status") EnrollmentStatus status);
+	@Query(
+		"select e from Enrollment e " + "where e.studentId = :studentId " + "and e.status = :status")
+	List<Enrollment> findByStudentIdAndStatus(
+		@Param("studentId") UUID studentId, @Param("status") EnrollmentStatus status);
+
+	List<Enrollment> findAllByIdIn(List<UUID> ids);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
@@ -1,42 +1,40 @@
 package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.goggles.lecture_service.domain.enrollment.Enrollment;
-import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
-
 public interface EnrollmentJpaRepository extends JpaRepository<Enrollment, UUID> {
 
-	@Query(
-		"select e from Enrollment e "
-			+ "where e.orderId = :orderId "
-			+ "and e.lectureSnapshot.lectureId = :lectureId")
-	Optional<Enrollment> findByOrderIdAndLectureId(
-		@Param("orderId") UUID orderId, @Param("lectureId") UUID lectureId);
+  @Query(
+      "select e from Enrollment e "
+          + "where e.orderId = :orderId "
+          + "and e.lectureSnapshot.lectureId = :lectureId")
+  Optional<Enrollment> findByOrderIdAndLectureId(
+      @Param("orderId") UUID orderId, @Param("lectureId") UUID lectureId);
 
-	@Query(
-		"select count(e) > 0 from Enrollment e "
-			+ "where e.studentId = :studentId "
-			+ "and e.lectureSnapshot.lectureId = :lectureId "
-			+ "and e.status in :statuses")
-	boolean existsByStudentAndLectureAndStatusIn(
-		@Param("studentId") UUID studentId,
-		@Param("lectureId") UUID lectureId,
-		@Param("statuses") Collection<EnrollmentStatus> statuses);
+  @Query(
+      "select count(e) > 0 from Enrollment e "
+          + "where e.studentId = :studentId "
+          + "and e.lectureSnapshot.lectureId = :lectureId "
+          + "and e.status in :statuses")
+  boolean existsByStudentAndLectureAndStatusIn(
+      @Param("studentId") UUID studentId,
+      @Param("lectureId") UUID lectureId,
+      @Param("statuses") Collection<EnrollmentStatus> statuses);
 
-	List<Enrollment> findAllByOrderId(UUID orderId);
+  List<Enrollment> findAllByOrderId(UUID orderId);
 
-	@Query(
-		"select e from Enrollment e " + "where e.studentId = :studentId " + "and e.status = :status")
-	List<Enrollment> findByStudentIdAndStatus(
-		@Param("studentId") UUID studentId, @Param("status") EnrollmentStatus status);
+  @Query(
+      "select e from Enrollment e " + "where e.studentId = :studentId " + "and e.status = :status")
+  List<Enrollment> findByStudentIdAndStatus(
+      @Param("studentId") UUID studentId, @Param("status") EnrollmentStatus status);
 
-	List<Enrollment> findAllByIdIn(List<UUID> ids);
+  List<Enrollment> findAllByIdIn(List<UUID> ids);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -1,53 +1,61 @@
 package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
-import com.goggles.lecture_service.domain.enrollment.Enrollment;
-import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
-import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
 public class EnrollmentRepositoryImpl implements EnrollmentRepository {
 
-  private static final Set<EnrollmentStatus> ACTIVE_OR_RESERVED =
-      EnumSet.of(EnrollmentStatus.RESERVE, EnrollmentStatus.ACTIVE);
+	private static final Set<EnrollmentStatus> ACTIVE_OR_RESERVED =
+		EnumSet.of(EnrollmentStatus.RESERVE, EnrollmentStatus.ACTIVE);
 
-  private final EnrollmentJpaRepository jpaRepository;
+	private final EnrollmentJpaRepository jpaRepository;
 
-  @Override
-  public Enrollment save(Enrollment enrollment) {
-    return jpaRepository.save(enrollment);
-  }
+	@Override
+	public Enrollment save(Enrollment enrollment) {
+		return jpaRepository.save(enrollment);
+	}
 
-  @Override
-  public Optional<Enrollment> findById(UUID id) {
-    return jpaRepository.findById(id);
-  }
+	@Override
+	public Optional<Enrollment> findById(UUID id) {
+		return jpaRepository.findById(id);
+	}
 
-  @Override
-  public Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId) {
-    return jpaRepository.findByOrderIdAndLectureId(orderId, lectureId);
-  }
+	@Override
+	public List<Enrollment> findAllByIdIn(List<UUID> ids) {
+		return jpaRepository.findAllByIdIn(ids);
+	}
 
-  @Override
-  public boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId) {
-    return jpaRepository.existsByStudentAndLectureAndStatusIn(
-        studentId, lectureId, ACTIVE_OR_RESERVED);
-  }
+	@Override
+	public Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId) {
+		return jpaRepository.findByOrderIdAndLectureId(orderId, lectureId);
+	}
 
-  @Override
-  public List<Enrollment> findAllByOrderId(UUID orderId) {
-    return jpaRepository.findAllByOrderId(orderId);
-  }
+	@Override
+	public boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId) {
+		return jpaRepository.existsByStudentAndLectureAndStatusIn(
+			studentId, lectureId, ACTIVE_OR_RESERVED);
+	}
 
-  @Override
-  public List<Enrollment> findActiveByStudentId(UUID studentId) {
-    return jpaRepository.findByStudentIdAndStatus(studentId, EnrollmentStatus.ACTIVE);
-  }
+	@Override
+	public List<Enrollment> findAllByOrderId(UUID orderId) {
+		return jpaRepository.findAllByOrderId(orderId);
+	}
+
+	@Override
+	public List<Enrollment> findActiveByStudentId(UUID studentId) {
+		return jpaRepository.findByStudentIdAndStatus(studentId, EnrollmentStatus.ACTIVE);
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -1,61 +1,58 @@
 package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-
-import org.springframework.stereotype.Repository;
-
-import com.goggles.lecture_service.domain.enrollment.Enrollment;
-import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
-import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class EnrollmentRepositoryImpl implements EnrollmentRepository {
 
-	private static final Set<EnrollmentStatus> ACTIVE_OR_RESERVED =
-		EnumSet.of(EnrollmentStatus.RESERVE, EnrollmentStatus.ACTIVE);
+  private static final Set<EnrollmentStatus> ACTIVE_OR_RESERVED =
+      EnumSet.of(EnrollmentStatus.RESERVE, EnrollmentStatus.ACTIVE);
 
-	private final EnrollmentJpaRepository jpaRepository;
+  private final EnrollmentJpaRepository jpaRepository;
 
-	@Override
-	public Enrollment save(Enrollment enrollment) {
-		return jpaRepository.save(enrollment);
-	}
+  @Override
+  public Enrollment save(Enrollment enrollment) {
+    return jpaRepository.save(enrollment);
+  }
 
-	@Override
-	public Optional<Enrollment> findById(UUID id) {
-		return jpaRepository.findById(id);
-	}
+  @Override
+  public Optional<Enrollment> findById(UUID id) {
+    return jpaRepository.findById(id);
+  }
 
-	@Override
-	public List<Enrollment> findAllByIdIn(List<UUID> ids) {
-		return jpaRepository.findAllByIdIn(ids);
-	}
+  @Override
+  public List<Enrollment> findAllByIdIn(List<UUID> ids) {
+    return jpaRepository.findAllByIdIn(ids);
+  }
 
-	@Override
-	public Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId) {
-		return jpaRepository.findByOrderIdAndLectureId(orderId, lectureId);
-	}
+  @Override
+  public Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId) {
+    return jpaRepository.findByOrderIdAndLectureId(orderId, lectureId);
+  }
 
-	@Override
-	public boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId) {
-		return jpaRepository.existsByStudentAndLectureAndStatusIn(
-			studentId, lectureId, ACTIVE_OR_RESERVED);
-	}
+  @Override
+  public boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId) {
+    return jpaRepository.existsByStudentAndLectureAndStatusIn(
+        studentId, lectureId, ACTIVE_OR_RESERVED);
+  }
 
-	@Override
-	public List<Enrollment> findAllByOrderId(UUID orderId) {
-		return jpaRepository.findAllByOrderId(orderId);
-	}
+  @Override
+  public List<Enrollment> findAllByOrderId(UUID orderId) {
+    return jpaRepository.findAllByOrderId(orderId);
+  }
 
-	@Override
-	public List<Enrollment> findActiveByStudentId(UUID studentId) {
-		return jpaRepository.findByStudentIdAndStatus(studentId, EnrollmentStatus.ACTIVE);
-	}
+  @Override
+  public List<Enrollment> findActiveByStudentId(UUID studentId) {
+    return jpaRepository.findByStudentIdAndStatus(studentId, EnrollmentStatus.ACTIVE);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
@@ -1,13 +1,8 @@
 package com.goggles.lecture_service.presentation.enrollment.internal;
 
-import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandService;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentCancelRequest;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
-import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,32 +11,41 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandService;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentCancelRequest;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/internal/v1/lectures-enrollment")
 @RequiredArgsConstructor
 public class InternalLectureEnrollmentController {
 
-  private final EnrollmentCommandService enrollmentCommandService;
+	private final EnrollmentCommandService enrollmentCommandService;
 
-  @PostMapping("/reserve")
-  @ResponseStatus(HttpStatus.CREATED)
-  public List<LectureEnrollmentReserveResponse> reserve(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @Valid @RequestBody LectureEnrollmentReserveRequest request) {
+	// TODO: 권한 정책 확정 후 userRole 기반 내부 API 접근 제어 적용
+	@PostMapping("/reserve")
+	@ResponseStatus(HttpStatus.CREATED)
+	public List<LectureEnrollmentReserveResponse> reserve(
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String userRole,
+		@Valid @RequestBody LectureEnrollmentReserveRequest request) {
 
-    return enrollmentCommandService.reserve(request.toCommand(userId)).stream()
-        .map(LectureEnrollmentReserveResponse::from)
-        .toList();
-  }
+		return enrollmentCommandService.reserve(request.toCommand(userId)).stream()
+			.map(LectureEnrollmentReserveResponse::from)
+			.toList();
+	}
 
-  @PostMapping("/cancellation")
-  @ResponseStatus(HttpStatus.OK)
-  public void cancel(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @Valid @RequestBody LectureEnrollmentCancelRequest request) {
+	@PostMapping("/cancellation")
+	@ResponseStatus(HttpStatus.OK)
+	public void cancel(
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String userRole,
+		@Valid @RequestBody LectureEnrollmentCancelRequest request) {
 
-    enrollmentCommandService.cancel(request.toCommand(userId));
-  }
+		enrollmentCommandService.cancel(request.toCommand(userId));
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
@@ -1,6 +1,7 @@
 package com.goggles.lecture_service.presentation.enrollment.internal;
 
 import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandService;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentCancelRequest;
 import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
 import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
 import jakarta.validation.Valid;
@@ -27,5 +28,11 @@ public class InternalLectureEnrollmentController {
     return enrollmentCommandService.reserve(request.toCommand()).stream()
         .map(LectureEnrollmentReserveResponse::from)
         .toList();
+  }
+
+  @PostMapping("/cancellation")
+  @ResponseStatus(HttpStatus.OK)
+  public void cancel(@Valid @RequestBody LectureEnrollmentCancelRequest request) {
+    enrollmentCommandService.cancel(request.toCommand());
   }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
@@ -6,10 +6,12 @@ import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureE
 import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,15 +26,22 @@ public class InternalLectureEnrollmentController {
   @PostMapping("/reserve")
   @ResponseStatus(HttpStatus.CREATED)
   public List<LectureEnrollmentReserveResponse> reserve(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
       @Valid @RequestBody LectureEnrollmentReserveRequest request) {
-    return enrollmentCommandService.reserve(request.toCommand()).stream()
+
+    return enrollmentCommandService.reserve(request.toCommand(userId)).stream()
         .map(LectureEnrollmentReserveResponse::from)
         .toList();
   }
 
   @PostMapping("/cancellation")
   @ResponseStatus(HttpStatus.OK)
-  public void cancel(@Valid @RequestBody LectureEnrollmentCancelRequest request) {
-    enrollmentCommandService.cancel(request.toCommand());
+  public void cancel(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @Valid @RequestBody LectureEnrollmentCancelRequest request) {
+
+    enrollmentCommandService.cancel(request.toCommand(userId));
   }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentCancelRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentCancelRequest.java
@@ -1,19 +1,16 @@
 package com.goggles.lecture_service.presentation.enrollment.internal.dto;
 
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
-import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
-
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-
 public record LectureEnrollmentCancelRequest(
-	@NotEmpty(message = "enrollmentIds 는 비어있을 수 없습니다.")
-	List<@NotNull(message = "enrollmentId 는 필수입니다.") UUID> enrollmentIds,
-	@NotNull(message = "userId 는 필수입니다.") UUID userId) {
+    @NotEmpty(message = "enrollmentIds 는 비어있을 수 없습니다.")
+        List<@NotNull(message = "enrollmentId 는 필수입니다.") UUID> enrollmentIds) {
 
-	public LectureEnrollmentCancelCommand toCommand() {
-		return new LectureEnrollmentCancelCommand(enrollmentIds, userId);
-	}
+  public LectureEnrollmentCancelCommand toCommand(UUID userId) {
+    return new LectureEnrollmentCancelCommand(enrollmentIds, userId);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentCancelRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentCancelRequest.java
@@ -1,0 +1,16 @@
+package com.goggles.lecture_service.presentation.enrollment.internal.dto;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+public record LectureEnrollmentCancelRequest(
+    @NotEmpty(message = "enrollmentIds 는 비어있을 수 없습니다.") List<UUID> enrollmentIds,
+    @NotNull(message = "userId 는 필수입니다.") UUID userId) {
+
+  public LectureEnrollmentCancelCommand toCommand() {
+    return new LectureEnrollmentCancelCommand(enrollmentIds, userId);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentCancelRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentCancelRequest.java
@@ -1,16 +1,19 @@
 package com.goggles.lecture_service.presentation.enrollment.internal.dto;
 
-import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
-public record LectureEnrollmentCancelRequest(
-    @NotEmpty(message = "enrollmentIds 는 비어있을 수 없습니다.") List<UUID> enrollmentIds,
-    @NotNull(message = "userId 는 필수입니다.") UUID userId) {
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 
-  public LectureEnrollmentCancelCommand toCommand() {
-    return new LectureEnrollmentCancelCommand(enrollmentIds, userId);
-  }
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record LectureEnrollmentCancelRequest(
+	@NotEmpty(message = "enrollmentIds 는 비어있을 수 없습니다.")
+	List<@NotNull(message = "enrollmentId 는 필수입니다.") UUID> enrollmentIds,
+	@NotNull(message = "userId 는 필수입니다.") UUID userId) {
+
+	public LectureEnrollmentCancelCommand toCommand() {
+		return new LectureEnrollmentCancelCommand(enrollmentIds, userId);
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentReserveRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentReserveRequest.java
@@ -1,18 +1,16 @@
 package com.goggles.lecture_service.presentation.enrollment.internal.dto;
 
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
 public record LectureEnrollmentReserveRequest(
-    @NotEmpty(message = "productIds 는 비어있을 수 없습니다.") List<UUID> productIds,
-    @NotNull(message = "userId 는 필수입니다.") UUID userId,
-    @NotBlank(message = "userName 은 필수입니다.") String userName) {
+    @NotEmpty(message = "productIds 는 비어있을 수 없습니다.")
+        List<@NotNull(message = "productId 는 필수입니다.") UUID> productIds) {
 
-  public LectureEnrollmentReserveCommand toCommand() {
-    return new LectureEnrollmentReserveCommand(productIds, userId, userName);
+  public LectureEnrollmentReserveCommand toCommand(UUID userId) {
+    return new LectureEnrollmentReserveCommand(productIds, userId);
   }
 }

--- a/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
@@ -64,8 +64,7 @@ class EnrollmentCommandServiceImplTest {
       when(enrollmentRepository.save(any(Enrollment.class))).thenAnswer(inv -> inv.getArgument(0));
 
       List<LectureEnrollmentReserveResult> results =
-          service.reserve(
-              new LectureEnrollmentReserveCommand(List.of(lecture.getId()), userId, userName));
+          service.reserve(new LectureEnrollmentReserveCommand(List.of(lecture.getId()), userId));
 
       assertThat(results).hasSize(1);
       assertThat(results.get(0).productId()).isEqualTo(lecture.getId());
@@ -87,7 +86,7 @@ class EnrollmentCommandServiceImplTest {
       when(enrollmentRepository.save(any(Enrollment.class))).thenAnswer(inv -> inv.getArgument(0));
 
       List<LectureEnrollmentReserveResult> results =
-          service.reserve(new LectureEnrollmentReserveCommand(productIds, userId, userName));
+          service.reserve(new LectureEnrollmentReserveCommand(productIds, userId));
 
       assertThat(results).hasSize(2);
       assertThat(results)
@@ -99,7 +98,7 @@ class EnrollmentCommandServiceImplTest {
     @Test
     @DisplayName("실패: productIds가 비어 있으면 예외")
     void reserve_emptyProductIds_throws() {
-      assertThatThrownBy(() -> new LectureEnrollmentReserveCommand(List.of(), userId, userName))
+      assertThatThrownBy(() -> new LectureEnrollmentReserveCommand(List.of(), userId))
           .isInstanceOf(InvalidEnrollmentFieldException.class);
     }
 
@@ -115,9 +114,7 @@ class EnrollmentCommandServiceImplTest {
           .thenReturn(false);
 
       assertThatThrownBy(
-              () ->
-                  service.reserve(
-                      new LectureEnrollmentReserveCommand(productIds, userId, userName)))
+              () -> service.reserve(new LectureEnrollmentReserveCommand(productIds, userId)))
           .isInstanceOf(EnrollmentReserveFailedException.class)
           .extracting("reason")
           .isEqualTo(ReserveFailReason.NOT_PUBLISHED);
@@ -132,9 +129,7 @@ class EnrollmentCommandServiceImplTest {
       when(lectureRepository.findAllByIdIn(List.of(missing))).thenReturn(List.of());
 
       assertThatThrownBy(
-              () ->
-                  service.reserve(
-                      new LectureEnrollmentReserveCommand(List.of(missing), userId, userName)))
+              () -> service.reserve(new LectureEnrollmentReserveCommand(List.of(missing), userId)))
           .isInstanceOf(EnrollmentReserveFailedException.class)
           .extracting("reason")
           .isEqualTo(ReserveFailReason.LECTURE_NOT_FOUND);
@@ -149,8 +144,7 @@ class EnrollmentCommandServiceImplTest {
       assertThatThrownBy(
               () ->
                   service.reserve(
-                      new LectureEnrollmentReserveCommand(
-                          List.of(draft.getId()), userId, userName)))
+                      new LectureEnrollmentReserveCommand(List.of(draft.getId()), userId)))
           .isInstanceOf(EnrollmentReserveFailedException.class)
           .extracting("reason")
           .isEqualTo(ReserveFailReason.NOT_PUBLISHED);
@@ -167,8 +161,7 @@ class EnrollmentCommandServiceImplTest {
       assertThatThrownBy(
               () ->
                   service.reserve(
-                      new LectureEnrollmentReserveCommand(
-                          List.of(lecture.getId()), userId, userName)))
+                      new LectureEnrollmentReserveCommand(List.of(lecture.getId()), userId)))
           .isInstanceOf(EnrollmentReserveFailedException.class)
           .extracting("reason")
           .isEqualTo(ReserveFailReason.DUPLICATE_ENROLLMENT);
@@ -283,9 +276,7 @@ class EnrollmentCommandServiceImplTest {
       when(lectureRepository.findAllByIdIn(productIds)).thenReturn(List.of(lecture)); // 일부만 반환
 
       assertThatThrownBy(
-              () ->
-                  service.reserve(
-                      new LectureEnrollmentReserveCommand(productIds, userId, userName)))
+              () -> service.reserve(new LectureEnrollmentReserveCommand(productIds, userId)))
           .isInstanceOf(EnrollmentReserveFailedException.class)
           .extracting("reason")
           .isEqualTo(ReserveFailReason.LECTURE_NOT_FOUND);

--- a/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
@@ -166,6 +166,25 @@ class EnrollmentCommandServiceImplTest {
           .extracting("reason")
           .isEqualTo(ReserveFailReason.DUPLICATE_ENROLLMENT);
     }
+
+    @Test
+    @DisplayName("실패: 강의 일부만 조회되면 전체 실패")
+    void reserve_partialLectureMissing_throws() {
+      Lecture lecture = publishedLecture();
+      UUID missing = UUID.randomUUID();
+
+      List<UUID> productIds = List.of(lecture.getId(), missing);
+
+      when(lectureRepository.findAllByIdIn(productIds)).thenReturn(List.of(lecture)); // 일부만 반환
+
+      assertThatThrownBy(
+              () -> service.reserve(new LectureEnrollmentReserveCommand(productIds, userId)))
+          .isInstanceOf(EnrollmentReserveFailedException.class)
+          .extracting("reason")
+          .isEqualTo(ReserveFailReason.LECTURE_NOT_FOUND);
+
+      verify(enrollmentRepository, never()).save(any());
+    }
   }
 
   // --- 헬퍼: 테스트용 Lecture 생성 ---
@@ -263,25 +282,6 @@ class EnrollmentCommandServiceImplTest {
                   service.cancel(
                       new LectureEnrollmentCancelCommand(List.of(enrollment.getId()), userId)))
           .isInstanceOf(InvalidEnrollmentStatusException.class);
-    }
-
-    @Test
-    @DisplayName("실패: 강의 일부만 조회되면 전체 실패")
-    void reserve_partialLectureMissing_throws() {
-      Lecture lecture = publishedLecture();
-      UUID missing = UUID.randomUUID();
-
-      List<UUID> productIds = List.of(lecture.getId(), missing);
-
-      when(lectureRepository.findAllByIdIn(productIds)).thenReturn(List.of(lecture)); // 일부만 반환
-
-      assertThatThrownBy(
-              () -> service.reserve(new LectureEnrollmentReserveCommand(productIds, userId)))
-          .isInstanceOf(EnrollmentReserveFailedException.class)
-          .extracting("reason")
-          .isEqualTo(ReserveFailReason.LECTURE_NOT_FOUND);
-
-      verify(enrollmentRepository, never()).save(any());
     }
 
     // 헬퍼

--- a/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
@@ -4,13 +4,19 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
 import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandServiceImpl;
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.LectureSnapshot;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
 import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentNotFoundException;
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentNotOwnedException;
 import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserveFailedException;
 import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentStatusException;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
@@ -191,5 +197,107 @@ class EnrollmentCommandServiceImplTest {
   private Lecture draftLecture() {
     return Lecture.create(
         UUID.randomUUID(), "강사명", "BACKEND", "스프링 강의", "부제", "설명", DurationPolicy.DAYS_365, 10000L);
+  }
+
+  @Nested
+  @DisplayName("수강 등록 예약 취소")
+  class Cancel {
+
+    @Test
+    @DisplayName("성공: 단건 취소")
+    void cancel_singleEnrollment_success() {
+      Enrollment enrollment = reservedEnrollment(userId);
+      UUID enrollmentId = enrollment.getId();
+      when(enrollmentRepository.findAllByIdIn(List.of(enrollmentId)))
+          .thenReturn(List.of(enrollment));
+
+      service.cancel(new LectureEnrollmentCancelCommand(List.of(enrollmentId), userId));
+
+      assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("성공: 다건 취소")
+    void cancel_multiple_success() {
+      Enrollment a = reservedEnrollment(userId);
+      Enrollment b = reservedEnrollment(userId);
+      when(enrollmentRepository.findAllByIdIn(List.of(a.getId(), b.getId())))
+          .thenReturn(List.of(a, b));
+
+      service.cancel(new LectureEnrollmentCancelCommand(List.of(a.getId(), b.getId()), userId));
+
+      assertThat(a.getStatus()).isEqualTo(EnrollmentStatus.CANCELED);
+      assertThat(b.getStatus()).isEqualTo(EnrollmentStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("실패: 일부 enrollmentId 미존재")
+    void cancel_someNotFound_throws() {
+      UUID missing = UUID.randomUUID();
+      when(enrollmentRepository.findAllByIdIn(List.of(missing))).thenReturn(List.of());
+
+      assertThatThrownBy(
+              () -> service.cancel(new LectureEnrollmentCancelCommand(List.of(missing), userId)))
+          .isInstanceOf(EnrollmentNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 다른 학생 소유 enrollment 취소 시도")
+    void cancel_notOwned_throws() {
+      UUID otherUser = UUID.randomUUID();
+      Enrollment otherUserEnrollment = reservedEnrollment(otherUser);
+      when(enrollmentRepository.findAllByIdIn(List.of(otherUserEnrollment.getId())))
+          .thenReturn(List.of(otherUserEnrollment));
+
+      assertThatThrownBy(
+              () ->
+                  service.cancel(
+                      new LectureEnrollmentCancelCommand(
+                          List.of(otherUserEnrollment.getId()), userId)))
+          .isInstanceOf(EnrollmentNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 이미 CANCELED 상태 — 도메인 예외")
+    void cancel_alreadyCanceled_throws() {
+      Enrollment enrollment = reservedEnrollment(userId);
+      enrollment.cancel(); // 이미 CANCELED 로 만들어둠
+      when(enrollmentRepository.findAllByIdIn(List.of(enrollment.getId())))
+          .thenReturn(List.of(enrollment));
+
+      assertThatThrownBy(
+              () ->
+                  service.cancel(
+                      new LectureEnrollmentCancelCommand(List.of(enrollment.getId()), userId)))
+          .isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 강의 일부만 조회되면 전체 실패")
+    void reserve_partialLectureMissing_throws() {
+      Lecture lecture = publishedLecture();
+      UUID missing = UUID.randomUUID();
+
+      List<UUID> productIds = List.of(lecture.getId(), missing);
+
+      when(lectureRepository.findAllByIdIn(productIds)).thenReturn(List.of(lecture)); // 일부만 반환
+
+      assertThatThrownBy(
+              () ->
+                  service.reserve(
+                      new LectureEnrollmentReserveCommand(productIds, userId, userName)))
+          .isInstanceOf(EnrollmentReserveFailedException.class)
+          .extracting("reason")
+          .isEqualTo(ReserveFailReason.LECTURE_NOT_FOUND);
+
+      verify(enrollmentRepository, never()).save(any());
+    }
+
+    // 헬퍼
+    private Enrollment reservedEnrollment(UUID studentId) {
+      LectureSnapshot snapshot =
+          LectureSnapshot.of(UUID.randomUUID(), "스프링 강의", UUID.randomUUID(), "홍길동");
+      return Enrollment.reserve(snapshot, studentId, DurationPolicy.DAYS_365);
+    }
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #17
- 
### 💡 작업 내용
- 수강 등록 예약 취소 API (/internal/v1/lectures-enrollment/cancel) 구현
- 도메인 검증 로직을 Service → Domain(Lecture, Enrollment)으로 이동

### 🔍 변경 이유
- 결제 실패 및 보상 트랜잭션 대응을 위한 취소 API 필요
- 도메인 책임을 강화하여 유지보수성과 확장성 개선

### 📝 리뷰 포인트 (선택)
- 도메인 검증 위치가 적절한지 (Lecture.validateOrderable, Enrollment.reserve 등)
All-or-Nothing 처리 방식이 의도대로 동작하는지
예외 처리 구조 (ReserveFailReason 기반)가 적절한지

### 🧠 기타 참고 사항
- 내부 통신은 Feign 기반으로 order-service에서 호출 예정
Query 분리는 현재 기능 범위상 적용하지 않고, 추후 조회 기능 확장 시 도입 예정
- 17 브랜치가 16 위에서 생성되어 현재 PR에 16 커밋이 함께 보이기 때문에 base를 16으로 두었고, 16이 dev에 머지되면 base를 dev로 변경할 예정입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 강의 수강 신청 취소 기능 추가

## 테스트
* 수강 신청 취소 시나리오에 대한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->