### PR TITLE
[FEAT] 강의 수정,삭제 API 구현

### DIFF
--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,14 +1,5 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
@@ -22,86 +13,92 @@ import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserve
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
-	private final LectureRepository lectureRepository;
-	private final EnrollmentRepository enrollmentRepository;
+  private final LectureRepository lectureRepository;
+  private final EnrollmentRepository enrollmentRepository;
 
-	@Override
-	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
-		// 1) 강의 일괄 조회
-		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
-		Map<UUID, Lecture> lectureMap =
-			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+  @Override
+  public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+    // 1) 강의 일괄 조회
+    List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+    Map<UUID, Lecture> lectureMap =
+        lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-		// 2) 전체 검증
-		for (UUID productId : command.productIds()) {
-			Lecture lecture = lectureMap.get(productId);
+    // 2) 전체 검증
+    for (UUID productId : command.productIds()) {
+      Lecture lecture = lectureMap.get(productId);
 
-			if (lecture == null) {
-				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
-			}
+      if (lecture == null) {
+        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+      }
 
-			if (!lecture.isOrderable()) {
-				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
-			}
+      if (!lecture.isOrderable()) {
+        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
+      }
 
-			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
-				throw new EnrollmentReserveFailedException(
-					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
-			}
-		}
-		// 3) 검증 통과 후 Enrollment 저장
-		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+        throw new EnrollmentReserveFailedException(
+            productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+      }
+    }
+    // 3) 검증 통과 후 Enrollment 저장
+    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
-		for (UUID productId : command.productIds()) {
-			Lecture lecture = lectureMap.get(productId);
+    for (UUID productId : command.productIds()) {
+      Lecture lecture = lectureMap.get(productId);
 
-			LectureSnapshot snapshot =
-				LectureSnapshot.of(
-					lecture.getId(),
-					lecture.getContent().getTitle(),
-					lecture.getInstructor().getInstructorId(),
-					lecture.getInstructor().getInstructorName());
+      LectureSnapshot snapshot =
+          LectureSnapshot.of(
+              lecture.getId(),
+              lecture.getContent().getTitle(),
+              lecture.getInstructor().getInstructorId(),
+              lecture.getInstructor().getInstructorName());
 
-			Enrollment enrollment =
-				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+      Enrollment enrollment =
+          Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
 
-			Enrollment saved = enrollmentRepository.save(enrollment);
+      Enrollment saved = enrollmentRepository.save(enrollment);
 
-			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
-		}
+      results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+    }
 
-		return results;
-	}
+    return results;
+  }
 
-	@Override
-	public void cancel(LectureEnrollmentCancelCommand command) {
-		List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+  @Override
+  public void cancel(LectureEnrollmentCancelCommand command) {
+    List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
 
-		Map<UUID, Enrollment> enrollmentMap =
-			enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
+    Map<UUID, Enrollment> enrollmentMap =
+        enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
 
-		for (UUID enrollmentId : command.enrollmentIds()) {
-			Enrollment enrollment = enrollmentMap.get(enrollmentId);
+    for (UUID enrollmentId : command.enrollmentIds()) {
+      Enrollment enrollment = enrollmentMap.get(enrollmentId);
 
-			if (enrollment == null) {
-				throw new EnrollmentNotFoundException(enrollmentId);
-			}
+      if (enrollment == null) {
+        throw new EnrollmentNotFoundException(enrollmentId);
+      }
 
-			if (!enrollment.getStudentId().equals(command.userId())) {
-				throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
-			}
-		}
+      if (!enrollment.getStudentId().equals(command.userId())) {
+        throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
+      }
+    }
 
-		for (UUID enrollmentId : command.enrollmentIds()) {
-			enrollmentMap.get(enrollmentId).cancel();
-		}
-	}
+    for (UUID enrollmentId : command.enrollmentIds()) {
+      enrollmentMap.get(enrollmentId).cancel();
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -1,5 +1,14 @@
 package com.goggles.lecture_service.application.enrollment.command.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCancelCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
@@ -13,92 +22,86 @@ import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentReserve
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
 
-  private final LectureRepository lectureRepository;
-  private final EnrollmentRepository enrollmentRepository;
+	private final LectureRepository lectureRepository;
+	private final EnrollmentRepository enrollmentRepository;
 
-  @Override
-  public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
-    // 1) 강의 일괄 조회
-    List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
-    Map<UUID, Lecture> lectureMap =
-        lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
+	@Override
+	public List<LectureEnrollmentReserveResult> reserve(LectureEnrollmentReserveCommand command) {
+		// 1) 강의 일괄 조회
+		List<Lecture> lectures = lectureRepository.findAllByIdIn(command.productIds());
+		Map<UUID, Lecture> lectureMap =
+			lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-    // 2) 전체 검증
-    for (UUID productId : command.productIds()) {
-      Lecture lecture = lectureMap.get(productId);
+		// 2) 전체 검증
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
 
-      if (lecture == null) {
-        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
-      }
+			if (lecture == null) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.LECTURE_NOT_FOUND);
+			}
 
-      if (!lecture.isOrderable()) {
-        throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
-      }
+			if (!lecture.isOrderable()) {
+				throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
+			}
 
-      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
-        throw new EnrollmentReserveFailedException(
-            productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
-      }
-    }
-    // 3) 검증 통과 후 Enrollment 저장
-    List<LectureEnrollmentReserveResult> results = new ArrayList<>();
+			if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+				throw new EnrollmentReserveFailedException(
+					productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
+			}
+		}
+		// 3) 검증 통과 후 Enrollment 저장
+		List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
-    for (UUID productId : command.productIds()) {
-      Lecture lecture = lectureMap.get(productId);
+		for (UUID productId : command.productIds()) {
+			Lecture lecture = lectureMap.get(productId);
 
-      LectureSnapshot snapshot =
-          LectureSnapshot.of(
-              lecture.getId(),
-              lecture.getContent().getTitle(),
-              lecture.getInstructor().getInstructorId(),
-              lecture.getInstructor().getInstructorName());
+			LectureSnapshot snapshot =
+				LectureSnapshot.of(
+					lecture.getId(),
+					lecture.getContent().getTitle(),
+					lecture.getInstructor().getInstructorId(),
+					lecture.getInstructor().getInstructorName());
 
-      Enrollment enrollment =
-          Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
+			Enrollment enrollment =
+				Enrollment.reserve(snapshot, command.userId(), lecture.getDurationPolicy());
 
-      Enrollment saved = enrollmentRepository.save(enrollment);
+			Enrollment saved = enrollmentRepository.save(enrollment);
 
-      results.add(LectureEnrollmentReserveResult.of(saved, lecture));
-    }
+			results.add(LectureEnrollmentReserveResult.of(saved, lecture));
+		}
 
-    return results;
-  }
+		return results;
+	}
 
-  @Override
-  public void cancel(LectureEnrollmentCancelCommand command) {
-    List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+	@Override
+	public void cancel(LectureEnrollmentCancelCommand command) {
+		List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
 
-    Map<UUID, Enrollment> enrollmentMap =
-        enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
+		Map<UUID, Enrollment> enrollmentMap =
+			enrollments.stream().collect(Collectors.toMap(Enrollment::getId, enrollment -> enrollment));
 
-    for (UUID enrollmentId : command.enrollmentIds()) {
-      Enrollment enrollment = enrollmentMap.get(enrollmentId);
+		for (UUID enrollmentId : command.enrollmentIds()) {
+			Enrollment enrollment = enrollmentMap.get(enrollmentId);
 
-      if (enrollment == null) {
-        throw new EnrollmentNotFoundException(enrollmentId);
-      }
+			if (enrollment == null) {
+				throw new EnrollmentNotFoundException(enrollmentId);
+			}
 
-      if (!enrollment.getStudentId().equals(command.userId())) {
-        throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
-      }
-    }
+			if (!enrollment.getStudentId().equals(command.userId())) {
+				throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
+			}
+		}
 
-    for (UUID enrollmentId : command.enrollmentIds()) {
-      enrollmentMap.get(enrollmentId).cancel();
-    }
-  }
+		for (UUID enrollmentId : command.enrollmentIds()) {
+			enrollmentMap.get(enrollmentId).cancel();
+		}
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
@@ -1,7 +1,5 @@
 package com.goggles.lecture_service.application.lecture;
 
-import java.util.UUID;
-
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
@@ -15,19 +13,20 @@ import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdate
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
+import java.util.UUID;
 
 public interface LectureService {
 
-	CommonPageResponse<LectureSummary> getLectures(
-		LectureSearchCondition condition, CommonPageRequest pageRequest);
+  CommonPageResponse<LectureSummary> getLectures(
+      LectureSearchCondition condition, CommonPageRequest pageRequest);
 
-	LectureDetail getLectureDetail(UUID lectureId);
+  LectureDetail getLectureDetail(UUID lectureId);
 
-	LectureCreateResult createLecture(LectureCreateCommand command);
+  LectureCreateResult createLecture(LectureCreateCommand command);
 
-	ChapterCreateResult createChapter(ChapterCreateCommand command);
+  ChapterCreateResult createChapter(ChapterCreateCommand command);
 
-	LectureUpdateResult updateLecture(LectureUpdateCommand command);
+  LectureUpdateResult updateLecture(LectureUpdateCommand command);
 
-	LectureDeleteResult deleteLecture(LectureDeleteCommand command);
+  LectureDeleteResult deleteLecture(LectureDeleteCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
@@ -1,24 +1,33 @@
 package com.goggles.lecture_service.application.lecture;
 
+import java.util.UUID;
+
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
-import java.util.UUID;
 
 public interface LectureService {
 
-  CommonPageResponse<LectureSummary> getLectures(
-      LectureSearchCondition condition, CommonPageRequest pageRequest);
+	CommonPageResponse<LectureSummary> getLectures(
+		LectureSearchCondition condition, CommonPageRequest pageRequest);
 
-  LectureDetail getLectureDetail(UUID lectureId);
+	LectureDetail getLectureDetail(UUID lectureId);
 
-  LectureCreateResult createLecture(LectureCreateCommand command);
+	LectureCreateResult createLecture(LectureCreateCommand command);
 
-  ChapterCreateResult createChapter(ChapterCreateCommand command);
+	ChapterCreateResult createChapter(ChapterCreateCommand command);
+
+	LectureUpdateResult updateLecture(LectureUpdateCommand command);
+
+	LectureDeleteResult deleteLecture(LectureDeleteCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
@@ -1,45 +1,62 @@
 package com.goggles.lecture_service.application.lecture;
 
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
 import com.goggles.lecture_service.application.lecture.command.service.LectureCommandService;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.application.lecture.query.service.LectureQueryService;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class LectureServiceImpl implements LectureService {
 
-  private final LectureQueryService lectureQueryService;
-  private final LectureCommandService lectureCommandService;
+	private final LectureQueryService lectureQueryService;
+	private final LectureCommandService lectureCommandService;
 
-  @Override
-  public CommonPageResponse<LectureSummary> getLectures(
-      LectureSearchCondition condition, CommonPageRequest pageRequest) {
-    return lectureQueryService.getLectures(condition, pageRequest);
-  }
+	@Override
+	public CommonPageResponse<LectureSummary> getLectures(
+		LectureSearchCondition condition, CommonPageRequest pageRequest) {
+		return lectureQueryService.getLectures(condition, pageRequest);
+	}
 
-  @Override
-  public LectureDetail getLectureDetail(UUID lectureId) {
-    return lectureQueryService.getLectureDetail(lectureId);
-  }
+	@Override
+	public LectureDetail getLectureDetail(UUID lectureId) {
+		return lectureQueryService.getLectureDetail(lectureId);
+	}
 
-  @Override
-  public LectureCreateResult createLecture(LectureCreateCommand command) {
-    return lectureCommandService.createLecture(command);
-  }
+	@Override
+	public LectureCreateResult createLecture(LectureCreateCommand command) {
+		return lectureCommandService.createLecture(command);
+	}
 
-  @Override
-  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-    return lectureCommandService.createChapter(command);
-  }
+	@Override
+	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+		return lectureCommandService.createChapter(command);
+	}
+
+	@Override
+	public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
+		return lectureCommandService.updateLecture(command);
+	}
+
+	@Override
+	public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
+		return lectureCommandService.deleteLecture(command);
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
@@ -1,9 +1,5 @@
 package com.goggles.lecture_service.application.lecture;
 
-import java.util.UUID;
-
-import org.springframework.stereotype.Service;
-
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
@@ -19,44 +15,45 @@ import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.application.lecture.query.service.LectureQueryService;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
-
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class LectureServiceImpl implements LectureService {
 
-	private final LectureQueryService lectureQueryService;
-	private final LectureCommandService lectureCommandService;
+  private final LectureQueryService lectureQueryService;
+  private final LectureCommandService lectureCommandService;
 
-	@Override
-	public CommonPageResponse<LectureSummary> getLectures(
-		LectureSearchCondition condition, CommonPageRequest pageRequest) {
-		return lectureQueryService.getLectures(condition, pageRequest);
-	}
+  @Override
+  public CommonPageResponse<LectureSummary> getLectures(
+      LectureSearchCondition condition, CommonPageRequest pageRequest) {
+    return lectureQueryService.getLectures(condition, pageRequest);
+  }
 
-	@Override
-	public LectureDetail getLectureDetail(UUID lectureId) {
-		return lectureQueryService.getLectureDetail(lectureId);
-	}
+  @Override
+  public LectureDetail getLectureDetail(UUID lectureId) {
+    return lectureQueryService.getLectureDetail(lectureId);
+  }
 
-	@Override
-	public LectureCreateResult createLecture(LectureCreateCommand command) {
-		return lectureCommandService.createLecture(command);
-	}
+  @Override
+  public LectureCreateResult createLecture(LectureCreateCommand command) {
+    return lectureCommandService.createLecture(command);
+  }
 
-	@Override
-	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-		return lectureCommandService.createChapter(command);
-	}
+  @Override
+  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+    return lectureCommandService.createChapter(command);
+  }
 
-	@Override
-	public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
-		return lectureCommandService.updateLecture(command);
-	}
+  @Override
+  public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
+    return lectureCommandService.updateLecture(command);
+  }
 
-	@Override
-	public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
-		return lectureCommandService.deleteLecture(command);
-	}
+  @Override
+  public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
+    return lectureCommandService.deleteLecture(command);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureDeleteCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureDeleteCommand.java
@@ -1,0 +1,21 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+
+public record LectureDeleteCommand(UUID lectureId, UUID actorId, String actorRole) {
+
+	public LectureDeleteCommand {
+		if (lectureId == null) {
+			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
+		}
+		if (actorId == null) {
+			throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+		}
+		if (actorRole == null || actorRole.isBlank()) {
+			throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
+		}
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureDeleteCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureDeleteCommand.java
@@ -1,21 +1,20 @@
 package com.goggles.lecture_service.application.lecture.command.dto;
 
-import java.util.UUID;
-
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+import java.util.UUID;
 
 public record LectureDeleteCommand(UUID lectureId, UUID actorId, String actorRole) {
 
-	public LectureDeleteCommand {
-		if (lectureId == null) {
-			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
-		}
-		if (actorId == null) {
-			throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
-		}
-		if (actorRole == null || actorRole.isBlank()) {
-			throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
-		}
-	}
+  public LectureDeleteCommand {
+    if (lectureId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
+    }
+    if (actorId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+    }
+    if (actorRole == null || actorRole.isBlank()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureDeleteResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureDeleteResult.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 public record LectureDeleteResult(UUID lectureId) {
 
-	public static LectureDeleteResult from(UUID lectureId) {
-		return new LectureDeleteResult(lectureId);
-	}
+  public static LectureDeleteResult from(UUID lectureId) {
+    return new LectureDeleteResult(lectureId);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureDeleteResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureDeleteResult.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+public record LectureDeleteResult(UUID lectureId) {
+
+	public static LectureDeleteResult from(UUID lectureId) {
+		return new LectureDeleteResult(lectureId);
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateCommand.java
@@ -1,34 +1,33 @@
 package com.goggles.lecture_service.application.lecture.command.dto;
 
-import java.util.UUID;
-
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+import java.util.UUID;
 
 public record LectureUpdateCommand(
-	UUID lectureId,
-	UUID actorId,
-	String actorRole,
-	String category,
-	String title,
-	String subtitle,
-	String description,
-	DurationPolicy durationPolicy,
-	Long price) {
+    UUID lectureId,
+    UUID actorId,
+    String actorRole,
+    String category,
+    String title,
+    String subtitle,
+    String description,
+    DurationPolicy durationPolicy,
+    Long price) {
 
-	public LectureUpdateCommand {
-		if (lectureId == null) {
-			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
-		}
-		if (actorId == null) {
-			throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
-		}
-		if (actorRole == null || actorRole.isBlank()) {
-			throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
-		}
-		if (price == null) {
-			throw new InvalidLectureFieldException(LectureErrorCode.PRICE_REQUIRED);
-		}
-	}
+  public LectureUpdateCommand {
+    if (lectureId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
+    }
+    if (actorId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+    }
+    if (actorRole == null || actorRole.isBlank()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
+    }
+    if (price == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.PRICE_REQUIRED);
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateCommand.java
@@ -1,0 +1,34 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+
+public record LectureUpdateCommand(
+	UUID lectureId,
+	UUID actorId,
+	String actorRole,
+	String category,
+	String title,
+	String subtitle,
+	String description,
+	DurationPolicy durationPolicy,
+	Long price) {
+
+	public LectureUpdateCommand {
+		if (lectureId == null) {
+			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
+		}
+		if (actorId == null) {
+			throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+		}
+		if (actorRole == null || actorRole.isBlank()) {
+			throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
+		}
+		if (price == null) {
+			throw new InvalidLectureFieldException(LectureErrorCode.PRICE_REQUIRED);
+		}
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateCommand.java
@@ -29,5 +29,8 @@ public record LectureUpdateCommand(
     if (price == null) {
       throw new InvalidLectureFieldException(LectureErrorCode.PRICE_REQUIRED);
     }
+    if (durationPolicy == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_DURATION_POLICY_REQUIRED);
+    }
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateResult.java
@@ -1,0 +1,13 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+
+public record LectureUpdateResult(UUID lectureId, LectureStatus status) {
+
+	public static LectureUpdateResult from(Lecture lecture) {
+		return new LectureUpdateResult(lecture.getId(), lecture.getStatus());
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/LectureUpdateResult.java
@@ -1,13 +1,12 @@
 package com.goggles.lecture_service.application.lecture.command.dto;
 
-import java.util.UUID;
-
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import java.util.UUID;
 
 public record LectureUpdateResult(UUID lectureId, LectureStatus status) {
 
-	public static LectureUpdateResult from(Lecture lecture) {
-		return new LectureUpdateResult(lecture.getId(), lecture.getStatus());
-	}
+  public static LectureUpdateResult from(Lecture lecture) {
+    return new LectureUpdateResult(lecture.getId(), lecture.getStatus());
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
@@ -10,11 +10,11 @@ import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdate
 import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
 
 public interface LectureCommandService {
-	LectureCreateResult createLecture(LectureCreateCommand command);
+  LectureCreateResult createLecture(LectureCreateCommand command);
 
-	ChapterCreateResult createChapter(ChapterCreateCommand command);
+  ChapterCreateResult createChapter(ChapterCreateCommand command);
 
-	LectureUpdateResult updateLecture(LectureUpdateCommand command);
+  LectureUpdateResult updateLecture(LectureUpdateCommand command);
 
-	LectureDeleteResult deleteLecture(LectureDeleteCommand command);
+  LectureDeleteResult deleteLecture(LectureDeleteCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
@@ -4,9 +4,17 @@ import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreate
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
 
 public interface LectureCommandService {
-  LectureCreateResult createLecture(LectureCreateCommand command);
+	LectureCreateResult createLecture(LectureCreateCommand command);
 
-  ChapterCreateResult createChapter(ChapterCreateCommand command);
+	ChapterCreateResult createChapter(ChapterCreateCommand command);
+
+	LectureUpdateResult updateLecture(LectureUpdateCommand command);
+
+	LectureDeleteResult deleteLecture(LectureDeleteCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -1,10 +1,5 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
-import java.util.UUID;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
@@ -17,97 +12,98 @@ import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.exception.LectureAccessDeniedException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LectureCommandServiceImpl implements LectureCommandService {
 
-	private static final String ROLE_MASTER = "MASTER";
-	private final LectureRepository lectureRepository;
+  private static final String ROLE_MASTER = "MASTER";
+  private final LectureRepository lectureRepository;
 
-	@Override
-	public LectureCreateResult createLecture(LectureCreateCommand command) {
-		// Todo: APPROVED 상태 강사만 생성 가능 조건 추가
-		Lecture lecture =
-			Lecture.create(
-				command.instructorId(),
-				command.instructorName(),
-				command.category(),
-				command.title(),
-				command.subtitle(),
-				command.description(),
-				command.durationPolicy(),
-				command.price());
+  @Override
+  public LectureCreateResult createLecture(LectureCreateCommand command) {
+    // Todo: APPROVED 상태 강사만 생성 가능 조건 추가
+    Lecture lecture =
+        Lecture.create(
+            command.instructorId(),
+            command.instructorName(),
+            command.category(),
+            command.title(),
+            command.subtitle(),
+            command.description(),
+            command.durationPolicy(),
+            command.price());
 
-		Lecture saved = lectureRepository.save(lecture);
-		return LectureCreateResult.from(saved);
-	}
+    Lecture saved = lectureRepository.save(lecture);
+    return LectureCreateResult.from(saved);
+  }
 
-	@Override
-	@Transactional
-	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  @Transactional
+  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		UUID chapterId =
-			lecture.addChapter(
-				command.title(), command.content(), command.sortOrder(), command.durationSeconds());
+    UUID chapterId =
+        lecture.addChapter(
+            command.title(), command.content(), command.sortOrder(), command.durationSeconds());
 
-		return ChapterCreateResult.from(lecture.getId(), chapterId);
-	}
+    return ChapterCreateResult.from(lecture.getId(), chapterId);
+  }
 
-	@Override
-	public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-		lecture.updateMetadata(
-			command.title(),
-			command.subtitle(),
-			command.description(),
-			command.category(),
-			command.durationPolicy(),
-			command.price());
+    lecture.updateMetadata(
+        command.title(),
+        command.subtitle(),
+        command.description(),
+        command.category(),
+        command.durationPolicy(),
+        command.price());
 
-		return LectureUpdateResult.from(lecture);
-	}
+    return LectureUpdateResult.from(lecture);
+  }
 
-	@Override
-	public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-		lecture.delete(command.actorId());
+    lecture.delete(command.actorId());
 
-		return LectureDeleteResult.from(command.lectureId());
-	}
+    return LectureDeleteResult.from(command.lectureId());
+  }
 
-	// 강의 소유자(강사) 또는 관리자(MASTER)만 통과
-	private void validateLectureAccess(Lecture lecture, UUID actorId, String actorRole) {
-		if (lecture.isOwnedBy(actorId) || isAdmin(actorRole)) {
-			return;
-		}
-		throw new LectureAccessDeniedException();
-	}
+  // 강의 소유자(강사) 또는 관리자(MASTER)만 통과
+  private void validateLectureAccess(Lecture lecture, UUID actorId, String actorRole) {
+    if (lecture.isOwnedBy(actorId) || isAdmin(actorRole)) {
+      return;
+    }
+    throw new LectureAccessDeniedException();
+  }
 
-	private boolean isAdmin(String actorRole) {
-		// TODO(#로그인): user-service 로그인 API 연동 후 공통 UserRole enum 으로 교체
-		//   위에 상수도 제거
-		//return actorRole == UserRole.MASTER;
-		return ROLE_MASTER.equals(actorRole);
-	}
-
+  private boolean isAdmin(String actorRole) {
+    // TODO(#로그인): user-service 로그인 API 연동 후 공통 UserRole enum 으로 교체
+    //   위에 상수도 제거
+    // return actorRole == UserRole.MASTER;
+    return ROLE_MASTER.equals(actorRole);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -1,54 +1,113 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
 import com.goggles.lecture_service.domain.lecture.Lecture;
+import com.goggles.lecture_service.domain.lecture.exception.LectureAccessDeniedException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LectureCommandServiceImpl implements LectureCommandService {
 
-  private final LectureRepository lectureRepository;
+	private static final String ROLE_MASTER = "MASTER";
+	private final LectureRepository lectureRepository;
 
-  @Override
-  public LectureCreateResult createLecture(LectureCreateCommand command) {
-    // Todo: APPROVED 상태 강사만 생성 가능 조건 추가
-    Lecture lecture =
-        Lecture.create(
-            command.instructorId(),
-            command.instructorName(),
-            command.category(),
-            command.title(),
-            command.subtitle(),
-            command.description(),
-            command.durationPolicy(),
-            command.price());
+	@Override
+	public LectureCreateResult createLecture(LectureCreateCommand command) {
+		// Todo: APPROVED 상태 강사만 생성 가능 조건 추가
+		Lecture lecture =
+			Lecture.create(
+				command.instructorId(),
+				command.instructorName(),
+				command.category(),
+				command.title(),
+				command.subtitle(),
+				command.description(),
+				command.durationPolicy(),
+				command.price());
 
-    Lecture saved = lectureRepository.save(lecture);
-    return LectureCreateResult.from(saved);
-  }
+		Lecture saved = lectureRepository.save(lecture);
+		return LectureCreateResult.from(saved);
+	}
 
-  @Override
-  @Transactional
-  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-    Lecture lecture =
-        lectureRepository
-            .findById(command.lectureId())
-            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+	@Override
+	@Transactional
+	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    UUID chapterId =
-        lecture.addChapter(
-            command.title(), command.content(), command.sortOrder(), command.durationSeconds());
+		UUID chapterId =
+			lecture.addChapter(
+				command.title(), command.content(), command.sortOrder(), command.durationSeconds());
 
-    return ChapterCreateResult.from(lecture.getId(), chapterId);
-  }
+		return ChapterCreateResult.from(lecture.getId(), chapterId);
+	}
+
+	@Override
+	public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+
+		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+
+		lecture.updateMetadata(
+			command.title(),
+			command.subtitle(),
+			command.description(),
+			command.category(),
+			command.durationPolicy(),
+			command.price());
+
+		return LectureUpdateResult.from(lecture);
+	}
+
+	@Override
+	public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+
+		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+
+		lecture.delete(command.actorId());
+
+		return LectureDeleteResult.from(command.lectureId());
+	}
+
+	// 강의 소유자(강사) 또는 관리자(MASTER)만 통과
+	private void validateLectureAccess(Lecture lecture, UUID actorId, String actorRole) {
+		if (lecture.isOwnedBy(actorId) || isAdmin(actorRole)) {
+			return;
+		}
+		throw new LectureAccessDeniedException();
+	}
+
+	private boolean isAdmin(String actorRole) {
+		// TODO(#로그인): user-service 로그인 API 연동 후 공통 UserRole enum 으로 교체
+		//   위에 상수도 제거
+		//return actorRole == UserRole.MASTER;
+		return ROLE_MASTER.equals(actorRole);
+	}
+
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -163,6 +163,9 @@ public class Lecture extends BaseAudit {
 
   // 도메인 메서드 (삭제)
   public void delete(UUID deletedBy) {
+    if (deletedBy == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+    }
     validateDraftStatus();
     softDelete(deletedBy);
   }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,12 +1,5 @@
 package com.goggles.lecture_service.domain.lecture;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import org.hibernate.annotations.SQLRestriction;
-
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
@@ -17,7 +10,6 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldE
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -27,9 +19,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -38,205 +35,201 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-	@Id
-	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
-	private UUID id = UUID.randomUUID();
+  @Id
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id = UUID.randomUUID();
 
-	@Embedded
-	private Instructor instructor;
+  @Embedded private Instructor instructor;
 
-	@Column(nullable = false, length = 50)
-	private String category;
+  @Column(nullable = false, length = 50)
+  private String category;
 
-	@Embedded
-	private LectureContent content;
+  @Embedded private LectureContent content;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private DurationPolicy durationPolicy;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private DurationPolicy durationPolicy;
 
-	@Embedded
-	private Money price;
+  @Embedded private Money price;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private LectureStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private LectureStatus status;
 
-	@Column(columnDefinition = "TEXT")
-	private String rejectionReason;
+  @Column(columnDefinition = "TEXT")
+  private String rejectionReason;
 
-	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Chapter> chapters = new ArrayList<>();
+  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Chapter> chapters = new ArrayList<>();
 
-	// 정적 팩토리 메서드
-	public static Lecture create(
-		UUID instructorId,
-		String instructorName,
-		String category,
-		String title,
-		String subtitle,
-		String description,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
+  // 정적 팩토리 메서드
+  public static Lecture create(
+      UUID instructorId,
+      String instructorName,
+      String category,
+      String title,
+      String subtitle,
+      String description,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
 
-		validateCategory(category);
+    validateCategory(category);
 
-		return new Lecture(
-			new Instructor(instructorId, instructorName),
-			category,
-			new LectureContent(title, subtitle, description),
-			durationPolicy,
-			Money.of(priceAmount));
-	}
+    return new Lecture(
+        new Instructor(instructorId, instructorName),
+        category,
+        new LectureContent(title, subtitle, description),
+        durationPolicy,
+        Money.of(priceAmount));
+  }
 
-	private Lecture(
-		Instructor instructor,
-		String category,
-		LectureContent content,
-		DurationPolicy durationPolicy,
-		Money price) {
-		this.instructor = instructor;
-		this.category = category;
-		this.content = content;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = price;
-		this.status = LectureStatus.DRAFT;
-	}
+  private Lecture(
+      Instructor instructor,
+      String category,
+      LectureContent content,
+      DurationPolicy durationPolicy,
+      Money price) {
+    this.instructor = instructor;
+    this.category = category;
+    this.content = content;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = price;
+    this.status = LectureStatus.DRAFT;
+  }
 
-	// 도메인 메서드 (챕터 관리)
-	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
-		validateDraftStatus();
-		validateDuplicateSortOrder(sortOrder);
+  // 도메인 메서드 (챕터 관리)
+  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
+    validateDraftStatus();
+    validateDuplicateSortOrder(sortOrder);
 
-		ChapterContent chapterContent = new ChapterContent(title, content);
-		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+    ChapterContent chapterContent = new ChapterContent(title, content);
+    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-		chapters.add(chapter);
+    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+    chapters.add(chapter);
 
-		return chapter.getId();
-	}
+    return chapter.getId();
+  }
 
-	public void removeChapter(UUID chapterId) {
-		validateDraftStatus();
-		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-		if (!removed) {
-			throw new ChapterNotFoundException(chapterId);
-		}
-	}
+  public void removeChapter(UUID chapterId) {
+    validateDraftStatus();
+    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+    if (!removed) {
+      throw new ChapterNotFoundException(chapterId);
+    }
+  }
 
-	public void reorderChapter(UUID chapterId, int newSortOrder) {
-		validateDraftStatus();
-		Chapter target = findChapterById(chapterId);
-		if (target.getSortOrder() == newSortOrder)
-			return;
-		validateDuplicateSortOrder(newSortOrder);
-		target.updateSortOrder(newSortOrder);
-	}
+  public void reorderChapter(UUID chapterId, int newSortOrder) {
+    validateDraftStatus();
+    Chapter target = findChapterById(chapterId);
+    if (target.getSortOrder() == newSortOrder) return;
+    validateDuplicateSortOrder(newSortOrder);
+    target.updateSortOrder(newSortOrder);
+  }
 
-	public List<Chapter> getChapters() {
-		return Collections.unmodifiableList(chapters);
-	}
+  public List<Chapter> getChapters() {
+    return Collections.unmodifiableList(chapters);
+  }
 
-	// 도메인 메서드 (정보 수정)
-	public void updateMetadata(
-		String title,
-		String subtitle,
-		String description,
-		String category,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
-		validateDraftStatus();
-		validateCategory(category);
+  // 도메인 메서드 (정보 수정)
+  public void updateMetadata(
+      String title,
+      String subtitle,
+      String description,
+      String category,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
+    validateDraftStatus();
+    validateCategory(category);
 
-		this.content = new LectureContent(title, subtitle, description);
-		this.category = category;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = Money.of(priceAmount);
-	}
+    this.content = new LectureContent(title, subtitle, description);
+    this.category = category;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = Money.of(priceAmount);
+  }
 
-	// 도메인 메서드 (상태 전이)
-	public void submitForReview() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (chapters.isEmpty()) {
-			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-		}
-		this.status = LectureStatus.PENDING_REVIEW;
-		// 리뷰 재신청 시 이전 이유 삭제
-		this.rejectionReason = null;
-	}
+  // 도메인 메서드 (상태 전이)
+  public void submitForReview() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (chapters.isEmpty()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
+    }
+    this.status = LectureStatus.PENDING_REVIEW;
+    // 리뷰 재신청 시 이전 이유 삭제
+    this.rejectionReason = null;
+  }
 
-	// 도메인 메서드 (삭제)
-	public void delete(UUID deletedBy) {
-		validateDraftStatus();
-		softDelete(deletedBy);
-	}
+  // 도메인 메서드 (삭제)
+  public void delete(UUID deletedBy) {
+    validateDraftStatus();
+    softDelete(deletedBy);
+  }
 
-	public void approve() {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.PUBLISHED;
-		this.rejectionReason = null;
-	}
+  public void approve() {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.PUBLISHED;
+    this.rejectionReason = null;
+  }
 
-	public void reject(String reason) {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (reason == null || reason.isBlank()) {
-			throw new InvalidRejectionReasonException();
-		}
-		this.status = LectureStatus.DRAFT;
-		this.rejectionReason = reason;
-	}
+  public void reject(String reason) {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new InvalidRejectionReasonException();
+    }
+    this.status = LectureStatus.DRAFT;
+    this.rejectionReason = reason;
+  }
 
-	public void hide() {
-		if (this.status != LectureStatus.PUBLISHED) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.HIDDEN;
-	}
+  public void hide() {
+    if (this.status != LectureStatus.PUBLISHED) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.HIDDEN;
+  }
 
-	// 도메인 메서드 (소유자 확인)
-	public boolean isOwnedBy(UUID userId) {
-		if (userId == null || this.instructor == null) {
-			return false;
-		}
-		return userId.equals(this.instructor.getInstructorId());
-	}
+  // 도메인 메서드 (소유자 확인)
+  public boolean isOwnedBy(UUID userId) {
+    if (userId == null || this.instructor == null) {
+      return false;
+    }
+    return userId.equals(this.instructor.getInstructorId());
+  }
 
-	// 주문 가능 여부
-	public boolean isOrderable() {
-		return this.status == LectureStatus.PUBLISHED;
-	}
+  // 주문 가능 여부
+  public boolean isOrderable() {
+    return this.status == LectureStatus.PUBLISHED;
+  }
 
-	// 내부 검증 및 편의 메서드
-	private void validateDraftStatus() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-	}
+  // 내부 검증 및 편의 메서드
+  private void validateDraftStatus() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+  }
 
-	private void validateDuplicateSortOrder(int sortOrder) {
-		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-		if (isDuplicate) {
-			throw new DuplicateSortOrderException(sortOrder);
-		}
-	}
+  private void validateDuplicateSortOrder(int sortOrder) {
+    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+    if (isDuplicate) {
+      throw new DuplicateSortOrderException(sortOrder);
+    }
+  }
 
-	private Chapter findChapterById(UUID chapterId) {
-		return chapters.stream()
-			.filter(c -> c.getId().equals(chapterId))
-			.findFirst()
-			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
-	}
+  private Chapter findChapterById(UUID chapterId) {
+    return chapters.stream()
+        .filter(c -> c.getId().equals(chapterId))
+        .findFirst()
+        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
+  }
 
-	private static void validateCategory(String category) {
-		if (category == null || category.isBlank()) {
-			throw new InvalidCategoryException();
-		}
-	}
+  private static void validateCategory(String category) {
+    if (category == null || category.isBlank()) {
+      throw new InvalidCategoryException();
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -69,7 +69,6 @@ public class Lecture extends BaseAudit {
 	private List<Chapter> chapters = new ArrayList<>();
 
 	// 정적 팩토리 메서드
-
 	public static Lecture create(
 		UUID instructorId,
 		String instructorName,
@@ -105,7 +104,6 @@ public class Lecture extends BaseAudit {
 	}
 
 	// 도메인 메서드 (챕터 관리)
-
 	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
 		validateDraftStatus();
 		validateDuplicateSortOrder(sortOrder);
@@ -141,7 +139,6 @@ public class Lecture extends BaseAudit {
 	}
 
 	// 도메인 메서드 (정보 수정)
-
 	public void updateMetadata(
 		String title,
 		String subtitle,
@@ -159,7 +156,6 @@ public class Lecture extends BaseAudit {
 	}
 
 	// 도메인 메서드 (상태 전이)
-
 	public void submitForReview() {
 		if (this.status != LectureStatus.DRAFT) {
 			throw new InvalidLectureStatusException(id, status);
@@ -170,6 +166,12 @@ public class Lecture extends BaseAudit {
 		this.status = LectureStatus.PENDING_REVIEW;
 		// 리뷰 재신청 시 이전 이유 삭제
 		this.rejectionReason = null;
+	}
+
+	// 도메인 메서드 (삭제)
+	public void delete(UUID deletedBy) {
+		validateDraftStatus();
+		softDelete(deletedBy);
 	}
 
 	public void approve() {
@@ -198,13 +200,20 @@ public class Lecture extends BaseAudit {
 		this.status = LectureStatus.HIDDEN;
 	}
 
+	// 도메인 메서드 (소유자 확인)
+	public boolean isOwnedBy(UUID userId) {
+		if (userId == null || this.instructor == null) {
+			return false;
+		}
+		return userId.equals(this.instructor.getInstructorId());
+	}
+
 	// 주문 가능 여부
 	public boolean isOrderable() {
 		return this.status == LectureStatus.PUBLISHED;
 	}
 
 	// 내부 검증 및 편의 메서드
-
 	private void validateDraftStatus() {
 		if (this.status != LectureStatus.DRAFT) {
 			throw new InvalidLectureStatusException(id, status);

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureAccessDeniedException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.domain.lecture.exception;
+
+import com.goggles.common.exception.ForbiddenException;
+
+public class LectureAccessDeniedException extends ForbiddenException {
+
+	public LectureAccessDeniedException() {
+		super(LectureErrorCode.LECTURE_ACCESS_DENIED.getMessage());
+	}
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureAccessDeniedException.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureAccessDeniedException.java
@@ -4,7 +4,7 @@ import com.goggles.common.exception.ForbiddenException;
 
 public class LectureAccessDeniedException extends ForbiddenException {
 
-	public LectureAccessDeniedException() {
-		super(LectureErrorCode.LECTURE_ACCESS_DENIED.getMessage());
-	}
+  public LectureAccessDeniedException() {
+    super(LectureErrorCode.LECTURE_ACCESS_DENIED.getMessage());
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -7,34 +7,41 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum LectureErrorCode {
 
-  // 강의
-  LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
-  LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
-  LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
-  LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
-  LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
-  LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
-  LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
-  LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
+	// 강의
+	LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
+	LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+	LECTURE_ACCESS_DENIED("강의에 대한 접근 권한이 없습니다."),
+	LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
+	LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
+	LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
+	LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
+	LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
+	LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
+	LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
 
-  // 챕터
-  CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
-  CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
-  CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
-  CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
-  CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
-  CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
-  CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
-  CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
-  CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
+	// 요청 필드 검증
+	USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+	USER_ROLE_REQUIRED("사용자 권한은 필수입니다."),
 
-  // 가격
-  PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
+	// 챕터
+	CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
+	CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
+	CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
+	CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
+	CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
+	CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
+	CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
+	CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
+	CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
 
-  // 강사
-  INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
-  INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
-  INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
+	// 가격
+	PRICE_REQUIRED("가격은 필수입니다."),
+	PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
 
-  private final String message;
+	// 강사
+	INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+	INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+	INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
+
+	private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -7,41 +7,41 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum LectureErrorCode {
 
-	// 강의
-	LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
-	LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
-	LECTURE_ACCESS_DENIED("강의에 대한 접근 권한이 없습니다."),
-	LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
-	LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
-	LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
-	LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
-	LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
-	LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
-	LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
+  // 강의
+  LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
+  LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+  LECTURE_ACCESS_DENIED("강의에 대한 접근 권한이 없습니다."),
+  LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
+  LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
+  LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
+  LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
+  LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
+  LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
+  LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
 
-	// 요청 필드 검증
-	USER_ID_REQUIRED("사용자 ID는 필수입니다."),
-	USER_ROLE_REQUIRED("사용자 권한은 필수입니다."),
+  // 요청 필드 검증
+  USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+  USER_ROLE_REQUIRED("사용자 권한은 필수입니다."),
 
-	// 챕터
-	CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
-	CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
-	CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
-	CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
-	CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
-	CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
-	CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
-	CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
-	CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
+  // 챕터
+  CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
+  CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
+  CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
+  CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
+  CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
+  CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
+  CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
+  CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
+  CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
 
-	// 가격
-	PRICE_REQUIRED("가격은 필수입니다."),
-	PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
+  // 가격
+  PRICE_REQUIRED("가격은 필수입니다."),
+  PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
 
-	// 강사
-	INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
-	INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
-	INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
+  // 강사
+  INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+  INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+  INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
 
-	private final String message;
+  private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -22,6 +22,7 @@ public enum LectureErrorCode {
   // 요청 필드 검증
   USER_ID_REQUIRED("사용자 ID는 필수입니다."),
   USER_ROLE_REQUIRED("사용자 권한은 필수입니다."),
+  LECTURE_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
 
   // 챕터
   CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
@@ -1,8 +1,13 @@
 package com.goggles.lecture_service.presentation.enrollment.internal;
 
+import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandService;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentCancelRequest;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,41 +16,33 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandService;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentCancelRequest;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
-
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-
 @RestController
 @RequestMapping("/internal/v1/lectures-enrollment")
 @RequiredArgsConstructor
 public class InternalLectureEnrollmentController {
 
-	private final EnrollmentCommandService enrollmentCommandService;
+  private final EnrollmentCommandService enrollmentCommandService;
 
-	// TODO: 권한 정책 확정 후 userRole 기반 내부 API 접근 제어 적용
-	@PostMapping("/reserve")
-	@ResponseStatus(HttpStatus.CREATED)
-	public List<LectureEnrollmentReserveResponse> reserve(
-		@RequestHeader("X-User-Id") UUID userId,
-		@RequestHeader("X-User-Role") String userRole,
-		@Valid @RequestBody LectureEnrollmentReserveRequest request) {
+  // TODO: 권한 정책 확정 후 userRole 기반 내부 API 접근 제어 적용
+  @PostMapping("/reserve")
+  @ResponseStatus(HttpStatus.CREATED)
+  public List<LectureEnrollmentReserveResponse> reserve(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @Valid @RequestBody LectureEnrollmentReserveRequest request) {
 
-		return enrollmentCommandService.reserve(request.toCommand(userId)).stream()
-			.map(LectureEnrollmentReserveResponse::from)
-			.toList();
-	}
+    return enrollmentCommandService.reserve(request.toCommand(userId)).stream()
+        .map(LectureEnrollmentReserveResponse::from)
+        .toList();
+  }
 
-	@PostMapping("/cancellation")
-	@ResponseStatus(HttpStatus.OK)
-	public void cancel(
-		@RequestHeader("X-User-Id") UUID userId,
-		@RequestHeader("X-User-Role") String userRole,
-		@Valid @RequestBody LectureEnrollmentCancelRequest request) {
+  @PostMapping("/cancellation")
+  @ResponseStatus(HttpStatus.OK)
+  public void cancel(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @Valid @RequestBody LectureEnrollmentCancelRequest request) {
 
-		enrollmentCommandService.cancel(request.toCommand(userId));
-	}
+    enrollmentCommandService.cancel(request.toCommand(userId));
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
@@ -1,13 +1,8 @@
 package com.goggles.lecture_service.presentation.enrollment.internal;
 
-import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandService;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentCancelRequest;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
-import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
-import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,33 +11,41 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandService;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentCancelRequest;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/internal/v1/lectures-enrollment")
 @RequiredArgsConstructor
 public class InternalLectureEnrollmentController {
 
-  private final EnrollmentCommandService enrollmentCommandService;
+	private final EnrollmentCommandService enrollmentCommandService;
 
-  // TODO: 권한 정책 확정 후 userRole 기반 내부 API 접근 제어 적용
-  @PostMapping("/reserve")
-  @ResponseStatus(HttpStatus.CREATED)
-  public List<LectureEnrollmentReserveResponse> reserve(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @Valid @RequestBody LectureEnrollmentReserveRequest request) {
+	// TODO: 권한 정책 확정 후 userRole 기반 내부 API 접근 제어 적용
+	@PostMapping("/reserve")
+	@ResponseStatus(HttpStatus.CREATED)
+	public List<LectureEnrollmentReserveResponse> reserve(
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String userRole,
+		@Valid @RequestBody LectureEnrollmentReserveRequest request) {
 
-    return enrollmentCommandService.reserve(request.toCommand(userId)).stream()
-        .map(LectureEnrollmentReserveResponse::from)
-        .toList();
-  }
+		return enrollmentCommandService.reserve(request.toCommand(userId)).stream()
+			.map(LectureEnrollmentReserveResponse::from)
+			.toList();
+	}
 
-  @PostMapping("/cancellation")
-  @ResponseStatus(HttpStatus.OK)
-  public void cancel(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @Valid @RequestBody LectureEnrollmentCancelRequest request) {
+	@PostMapping("/cancellation")
+	@ResponseStatus(HttpStatus.OK)
+	public void cancel(
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String userRole,
+		@Valid @RequestBody LectureEnrollmentCancelRequest request) {
 
-    enrollmentCommandService.cancel(request.toCommand(userId));
-  }
+		enrollmentCommandService.cancel(request.toCommand(userId));
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
@@ -4,6 +4,9 @@ import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.LectureService;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureListQuery;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
@@ -11,12 +14,17 @@ import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateRequest
 import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateResponse;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateRequest;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateResponse;
+import com.goggles.lecture_service.presentation.lecture.dto.LectureDeleteResponse;
+import com.goggles.lecture_service.presentation.lecture.dto.LectureUpdateRequest;
+import com.goggles.lecture_service.presentation.lecture.dto.LectureUpdateResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -55,6 +63,33 @@ public class LectureController {
       @Valid @RequestBody LectureCreateRequest request) {
     return LectureCreateResponse.from(
         lectureService.createLecture(request.toCommand(instructorId, instructorName)));
+  }
+
+  // 강의 수정(DRAFT 상태에서만, 강사 본인 또는 MASTER)
+  @PatchMapping("/{lectureId}")
+  public LectureUpdateResponse updateLecture(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @PathVariable UUID lectureId,
+      @Valid @RequestBody LectureUpdateRequest request) {
+
+    LectureUpdateResult result =
+        lectureService.updateLecture(request.toCommand(lectureId, userId, userRole));
+
+    return LectureUpdateResponse.from(result);
+  }
+
+  // 강의 삭제 (DRAFT 상태에서만, 강사 본인 또는 MASTER, soft delete)
+  @DeleteMapping("/{lectureId}")
+  public LectureDeleteResponse deleteLecture(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @PathVariable UUID lectureId) {
+
+    LectureDeleteResult result =
+        lectureService.deleteLecture(new LectureDeleteCommand(lectureId, userId, userRole));
+
+    return LectureDeleteResponse.from(result);
   }
 
   // 챕터 생성

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/LectureDeleteResponse.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/LectureDeleteResponse.java
@@ -1,0 +1,11 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteResult;
+import java.util.UUID;
+
+public record LectureDeleteResponse(UUID lectureId) {
+
+  public static LectureDeleteResponse from(LectureDeleteResult result) {
+    return new LectureDeleteResponse(result.lectureId());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/LectureUpdateRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/LectureUpdateRequest.java
@@ -14,7 +14,7 @@ public record LectureUpdateRequest(
     @NotBlank(message = "제목은 필수입니다.") @Size(max = 200, message = "제목은 200자 이하여야 합니다.") String title,
     @Size(max = 300, message = "부제는 300자 이하여야 합니다.") String subtitle,
     String description,
-    DurationPolicy durationPolicy,
+    @NotNull(message = "수강 기간 정책은 필수입니다.") DurationPolicy durationPolicy,
     @NotNull(message = "가격은 필수입니다.") @Min(value = 0, message = "가격은 0원 이상이어야 합니다.") Long price) {
 
   public LectureUpdateCommand toCommand(UUID lectureId, UUID actorId, String actorRole) {

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/LectureUpdateRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/LectureUpdateRequest.java
@@ -1,0 +1,32 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateCommand;
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record LectureUpdateRequest(
+    @NotBlank(message = "카테고리는 필수입니다.") @Size(max = 50, message = "카테고리는 50자 이하여야 합니다.")
+        String category,
+    @NotBlank(message = "제목은 필수입니다.") @Size(max = 200, message = "제목은 200자 이하여야 합니다.") String title,
+    @Size(max = 300, message = "부제는 300자 이하여야 합니다.") String subtitle,
+    String description,
+    DurationPolicy durationPolicy,
+    @NotNull(message = "가격은 필수입니다.") @Min(value = 0, message = "가격은 0원 이상이어야 합니다.") Long price) {
+
+  public LectureUpdateCommand toCommand(UUID lectureId, UUID actorId, String actorRole) {
+    return new LectureUpdateCommand(
+        lectureId,
+        actorId,
+        actorRole,
+        category,
+        title,
+        subtitle,
+        description,
+        durationPolicy,
+        price);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/LectureUpdateResponse.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/LectureUpdateResponse.java
@@ -1,0 +1,12 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
+import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import java.util.UUID;
+
+public record LectureUpdateResponse(UUID lectureId, LectureStatus status) {
+
+  public static LectureUpdateResponse from(LectureUpdateResult result) {
+    return new LectureUpdateResponse(result.lectureId(), result.status());
+  }
+}

--- a/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
@@ -8,6 +8,10 @@ import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreate
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
 import com.goggles.lecture_service.application.lecture.command.service.LectureCommandServiceImpl;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
@@ -16,6 +20,7 @@ import com.goggles.lecture_service.domain.lecture.exception.DuplicateSortOrderEx
 import com.goggles.lecture_service.domain.lecture.exception.InvalidCategoryException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureAccessDeniedException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
 import java.util.Optional;
@@ -138,7 +143,7 @@ class LectureCommandServiceImplTest {
           .isInstanceOf(InvalidLectureFieldException.class);
       verify(lectureRepository, times(0)).save(any(Lecture.class));
     }
-  }
+  } // 강의 생성 끝
 
   @Nested
   @DisplayName("챕터 생성")
@@ -235,5 +240,255 @@ class LectureCommandServiceImplTest {
       assertThatThrownBy(() -> lectureCommandService.createChapter(chapterCommand))
           .isInstanceOf(InvalidLectureFieldException.class);
     }
+  } // 챕터 생성 끝
+
+  @Nested
+  @DisplayName("강의 수정")
+  class UpdateLecture {
+
+    @Test
+    @DisplayName("성공: 강의 소유자(강사)가 DRAFT 상태 강의 수정")
+    void updateLecture_byOwner_success() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLecture(instructorId);
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      LectureUpdateResult result =
+          lectureCommandService.updateLecture(
+              new LectureUpdateCommand(
+                  lecture.getId(),
+                  instructorId,
+                  "INSTRUCTOR",
+                  "BACKEND",
+                  "수정된 제목",
+                  "수정된 부제",
+                  "수정된 설명",
+                  DurationPolicy.DAYS_180,
+                  20000L));
+
+      assertThat(result.lectureId()).isEqualTo(lecture.getId());
+      assertThat(lecture.getContent().getTitle()).isEqualTo("수정된 제목");
+    }
+
+    @Test
+    @DisplayName("성공: 관리자(MASTER)가 DRAFT 상태 강의 수정")
+    void updateLecture_byMaster_success() {
+      Lecture lecture = draftLecture(UUID.randomUUID()); // 다른 강사 소유
+      UUID master = UUID.randomUUID();
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      LectureUpdateResult result =
+          lectureCommandService.updateLecture(
+              new LectureUpdateCommand(
+                  lecture.getId(),
+                  master,
+                  "MASTER",
+                  "BACKEND",
+                  "수정된 제목",
+                  null,
+                  null,
+                  DurationPolicy.DAYS_365,
+                  10000L));
+
+      assertThat(result.lectureId()).isEqualTo(lecture.getId());
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 강의 수정")
+    void updateLecture_lectureNotFound_throws() {
+      UUID lectureId = UUID.randomUUID();
+      when(lectureRepository.findById(lectureId)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.updateLecture(
+                      new LectureUpdateCommand(
+                          lectureId,
+                          UUID.randomUUID(),
+                          "INSTRUCTOR",
+                          "BACKEND",
+                          "제목",
+                          null,
+                          null,
+                          DurationPolicy.DAYS_365,
+                          10000L)))
+          .isInstanceOf(LectureNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("실패: DRAFT가 아닌 상태에서 수정")
+    void updateLecture_notDraft_throws() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = publishedLecture(instructorId); // PUBLISHED 상태
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.updateLecture(
+                      new LectureUpdateCommand(
+                          lecture.getId(),
+                          instructorId,
+                          "INSTRUCTOR",
+                          "BACKEND",
+                          "제목",
+                          null,
+                          null,
+                          DurationPolicy.DAYS_365,
+                          10000L)))
+          .isInstanceOf(InvalidLectureStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 강의 소유자가 아닌 강사가 수정")
+    void updateLecture_notOwner_throws() {
+      Lecture lecture = draftLecture(UUID.randomUUID()); // 다른 강사
+      UUID otherInstructor = UUID.randomUUID();
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.updateLecture(
+                      new LectureUpdateCommand(
+                          lecture.getId(),
+                          otherInstructor,
+                          "INSTRUCTOR",
+                          "BACKEND",
+                          "제목",
+                          null,
+                          null,
+                          DurationPolicy.DAYS_365,
+                          10000L)))
+          .isInstanceOf(LectureAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("실패: lectureId null Command 예외")
+    void updateLecture_nullLectureId_throws() {
+      assertThatThrownBy(
+              () ->
+                  new LectureUpdateCommand(
+                      null,
+                      UUID.randomUUID(),
+                      "INSTRUCTOR",
+                      "BACKEND",
+                      "제목",
+                      null,
+                      null,
+                      DurationPolicy.DAYS_365,
+                      10000L))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: actorRole blank Command 예외")
+    void updateLecture_blankActorRole_throws() {
+      assertThatThrownBy(
+              () ->
+                  new LectureUpdateCommand(
+                      UUID.randomUUID(),
+                      UUID.randomUUID(),
+                      "  ",
+                      "BACKEND",
+                      "제목",
+                      null,
+                      null,
+                      DurationPolicy.DAYS_365,
+                      10000L))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: price null Command 예외")
+    void updateLecture_nullPrice_throws() {
+      assertThatThrownBy(
+              () ->
+                  new LectureUpdateCommand(
+                      UUID.randomUUID(),
+                      UUID.randomUUID(),
+                      "INSTRUCTOR",
+                      "BACKEND",
+                      "제목",
+                      null,
+                      null,
+                      DurationPolicy.DAYS_365,
+                      null))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("강의 삭제")
+  class DeleteLecture {
+
+    @Test
+    @DisplayName("성공: 강의 소유자가 DRAFT 상태 강의 삭제")
+    void deleteLecture_byOwner_success() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLecture(instructorId);
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      LectureDeleteResult result =
+          lectureCommandService.deleteLecture(
+              new LectureDeleteCommand(lecture.getId(), instructorId, "INSTRUCTOR"));
+
+      assertThat(result.lectureId()).isEqualTo(lecture.getId());
+      assertThat(lecture.getDeletedAt()).isNotNull();
+      assertThat(lecture.getDeletedBy()).isEqualTo(instructorId);
+    }
+
+    @Test
+    @DisplayName("성공: 관리자(MASTER)가 다른 강사의 DRAFT 강의 삭제")
+    void deleteLecture_byMaster_success() {
+      Lecture lecture = draftLecture(UUID.randomUUID());
+      UUID master = UUID.randomUUID();
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      lectureCommandService.deleteLecture(
+          new LectureDeleteCommand(lecture.getId(), master, "MASTER"));
+
+      assertThat(lecture.getDeletedBy()).isEqualTo(master);
+    }
+
+    @Test
+    @DisplayName("실패: DRAFT가 아닌 강의 삭제")
+    void deleteLecture_notDraft_throws() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = publishedLecture(instructorId);
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.deleteLecture(
+                      new LectureDeleteCommand(lecture.getId(), instructorId, "INSTRUCTOR")))
+          .isInstanceOf(InvalidLectureStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 소유자도 관리자도 아닌 사용자가 삭제")
+    void deleteLecture_notOwnerNotAdmin_throws() {
+      Lecture lecture = draftLecture(UUID.randomUUID());
+      UUID stranger = UUID.randomUUID();
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.deleteLecture(
+                      new LectureDeleteCommand(lecture.getId(), stranger, "STUDENT")))
+          .isInstanceOf(LectureAccessDeniedException.class);
+    }
+  }
+
+  // 헬퍼
+  private Lecture draftLecture(UUID instructorId) {
+    return Lecture.create(
+        instructorId, "강사명", "BACKEND", "스프링 강의", "부제", "설명", DurationPolicy.DAYS_365, 10000L);
+  }
+
+  private Lecture publishedLecture(UUID instructorId) {
+    Lecture l = draftLecture(instructorId);
+    l.addChapter("챕터1", "내용", 1, 600);
+    l.submitForReview();
+    l.approve();
+    return l;
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #8

### 💡 작업 내용
- 강의 수정 API 구현
  - PATCH /api/v1/lectures/{lectureId}
- 강의 삭제 API 구현
  - DELETE /api/v1/lectures/{lectureId}
- 강의 수정/삭제 Command, Result, Request, Response DTO 추가
- Lecture.updateMetadata() 기반 강의 정보 수정 처리
- Lecture.delete() 도메인 메서드 추가
- 강의 소유자 또는 MASTER만 수정/삭제 가능하도록 권한 검증 로직 추가
- 접근 권한 없음 예외 추가
  - LectureAccessDeniedException
  - ForbiddenException 상속으로 403 응답 처리
- LectureErrorCode에 강의 ID, 사용자 ID, 사용자 권한, 접근 권한 관련 에러 코드 추가
- 강의 수정/삭제 성공 및 실패 케이스 단위 테스트 추가

### 🔍 변경 이유
- 강의 수정/삭제는 강의 소유자인 강사 또는 관리자만 수행할 수 있어야 하므로 Application 계층에서 권한 검증 로직을 추가했습니다
- 사용자 ID, 권한, 강의 ID 등 필수값 검증을 Command에서 처리하여 Application 진입 시점의 기본 검증을 명확히 했습니다

### 📝 리뷰 포인트
- 강의 수정/삭제 권한 검증을 Application Service에서 처리한 방식이 적절한지
  - 강의 소유자 또는 MASTER만 허용
- LectureAccessDeniedException을 ForbiddenException으로 처리하여 403 응답을 반환하는 방식이 적절한지
- DRAFT 상태에서만 수정/삭제 가능하도록 도메인 메서드에서 validateDraftStatus()를 호출한 구조가 적절한지

### 🧠 기타 참고 사항
- 현재 인증/인가 연동이 완성되지 않아 X-User-Id, X-User-Role 헤더를 통해 사용자 정보를 임시로 전달받고 있습니다.
- 추후 user-service 및 인증 시스템 연동 후 반영 예정입니다.
- 강의 수정/삭제는 DRAFT 상태에서만 가능합니다.
- 챕터 수정/삭제/순서 변경 API는 별도 후속 이슈에서 진행 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 강의 정보 수정 지원(카테고리, 제목, 부제목, 설명, 수강 기간 정책, 가격 등)
  * 강의 삭제 지원

* **버그 수정 / 개선**
  * 수정·삭제 요청 시 입력 검증 강화 및 관련 오류 메시지 추가
  * 소유권 및 관리자 권한 기반 접근 검증 적용

* **테스트**
  * 수정 및 삭제 흐름에 대한 단위/통합 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->