### PR TITLE
[FEAT] 챕터 수정·삭제·순서 변경 API 구현

### DIFF
--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
@@ -4,6 +4,12 @@ import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
@@ -29,4 +35,10 @@ public interface LectureService {
   LectureUpdateResult updateLecture(LectureUpdateCommand command);
 
   LectureDeleteResult deleteLecture(LectureDeleteCommand command);
+
+  ChapterUpdateResult updateChapter(ChapterUpdateCommand command);
+
+  ChapterDeleteResult deleteChapter(ChapterDeleteCommand command);
+
+  ChapterReorderResult reorderChapters(ChapterReorderCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
@@ -4,6 +4,12 @@ import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
@@ -55,5 +61,20 @@ public class LectureServiceImpl implements LectureService {
   @Override
   public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
     return lectureCommandService.deleteLecture(command);
+  }
+
+  @Override
+  public ChapterUpdateResult updateChapter(ChapterUpdateCommand command) {
+    return lectureCommandService.updateChapter(command);
+  }
+
+  @Override
+  public ChapterDeleteResult deleteChapter(ChapterDeleteCommand command) {
+    return lectureCommandService.deleteChapter(command);
+  }
+
+  @Override
+  public ChapterReorderResult reorderChapters(ChapterReorderCommand command) {
+    return lectureCommandService.reorderChapters(command);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterDeleteCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterDeleteCommand.java
@@ -1,0 +1,23 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+import java.util.UUID;
+
+public record ChapterDeleteCommand(UUID lectureId, UUID chapterId, UUID actorId, String actorRole) {
+
+  public ChapterDeleteCommand {
+    if (lectureId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
+    }
+    if (chapterId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_ID_REQUIRED);
+    }
+    if (actorId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+    }
+    if (actorRole == null || actorRole.isBlank()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
+    }
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterDeleteResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterDeleteResult.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+public record ChapterDeleteResult(UUID lectureId, UUID chapterId) {
+
+  public static ChapterDeleteResult from(UUID lectureId, UUID chapterId) {
+    return new ChapterDeleteResult(lectureId, chapterId);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterReorderCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterReorderCommand.java
@@ -1,0 +1,56 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+public record ChapterReorderCommand(
+    UUID lectureId, UUID actorId, String actorRole, List<ChapterOrderCommand> orders) {
+
+  public ChapterReorderCommand {
+    if (lectureId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
+    }
+    if (actorId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+    }
+    if (actorRole == null || actorRole.isBlank()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
+    }
+    if (orders == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_REORDER_ITEMS_REQUIRED);
+    }
+    if (orders.isEmpty()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_REORDER_ITEMS_EMPTY);
+    }
+    if (orders.stream().anyMatch(order -> order == null)) {
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_REORDER_ITEMS_REQUIRED);
+    }
+
+    boolean hasDuplicatedChapterId =
+        new HashSet<>(orders.stream().map(ChapterOrderCommand::chapterId).toList()).size()
+            != orders.size();
+    if (hasDuplicatedChapterId) {
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_ID_DUPLICATED);
+    }
+
+    orders = List.copyOf(orders);
+  }
+
+  public record ChapterOrderCommand(UUID chapterId, Integer sortOrder) {
+
+    public ChapterOrderCommand {
+      if (chapterId == null) {
+        throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_ID_REQUIRED);
+      }
+      if (sortOrder == null) {
+        throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_SORT_ORDER_REQUIRED);
+      }
+      if (sortOrder < 1) {
+        throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_INVALID_SORT_ORDER);
+      }
+    }
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterReorderResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterReorderResult.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+public record ChapterReorderResult(UUID lectureId) {
+
+  public static ChapterReorderResult from(UUID lectureId) {
+    return new ChapterReorderResult(lectureId);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterUpdateCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterUpdateCommand.java
@@ -1,0 +1,30 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
+import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+import java.util.UUID;
+
+public record ChapterUpdateCommand(
+    UUID lectureId,
+    UUID chapterId,
+    UUID actorId,
+    String actorRole,
+    String title,
+    String content,
+    Integer durationSeconds) {
+
+  public ChapterUpdateCommand {
+    if (lectureId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_ID_REQUIRED);
+    }
+    if (chapterId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.CHAPTER_ID_REQUIRED);
+    }
+    if (actorId == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+    }
+    if (actorRole == null || actorRole.isBlank()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ROLE_REQUIRED);
+    }
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterUpdateResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/dto/ChapterUpdateResult.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.application.lecture.command.dto;
+
+import java.util.UUID;
+
+public record ChapterUpdateResult(UUID lectureId, UUID chapterId) {
+
+  public static ChapterUpdateResult from(UUID lectureId, UUID chapterId) {
+    return new ChapterUpdateResult(lectureId, chapterId);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandService.java
@@ -2,6 +2,12 @@ package com.goggles.lecture_service.application.lecture.command.service;
 
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
@@ -17,4 +23,10 @@ public interface LectureCommandService {
   LectureUpdateResult updateLecture(LectureUpdateCommand command);
 
   LectureDeleteResult deleteLecture(LectureDeleteCommand command);
+
+  ChapterUpdateResult updateChapter(ChapterUpdateCommand command);
+
+  ChapterDeleteResult deleteChapter(ChapterDeleteCommand command);
+
+  ChapterReorderResult reorderChapters(ChapterReorderCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -2,6 +2,12 @@ package com.goggles.lecture_service.application.lecture.command.service;
 
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
@@ -12,7 +18,9 @@ import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.exception.LectureAccessDeniedException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,6 +98,56 @@ public class LectureCommandServiceImpl implements LectureCommandService {
     lecture.delete(command.actorId());
 
     return LectureDeleteResult.from(command.lectureId());
+  }
+
+  @Override
+  public ChapterUpdateResult updateChapter(ChapterUpdateCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
+
+    lecture.updateChapter(
+        command.chapterId(), command.title(), command.content(), command.durationSeconds());
+
+    return ChapterUpdateResult.from(lecture.getId(), command.chapterId());
+  }
+
+  @Override
+  public ChapterDeleteResult deleteChapter(ChapterDeleteCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
+
+    lecture.removeChapter(command.chapterId());
+
+    return ChapterDeleteResult.from(command.lectureId(), command.chapterId());
+  }
+
+  @Override
+  public ChapterReorderResult reorderChapters(ChapterReorderCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
+
+    Map<UUID, Integer> chapterOrders =
+        command.orders().stream()
+            .collect(
+                Collectors.toMap(
+                    ChapterReorderCommand.ChapterOrderCommand::chapterId,
+                    ChapterReorderCommand.ChapterOrderCommand::sortOrder));
+
+    lecture.reorderChapters(chapterOrders);
+
+    return ChapterReorderResult.from(command.lectureId());
   }
 
   // 강의 소유자(강사) 또는 관리자(MASTER)만 통과

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -1,5 +1,12 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteCommand;
@@ -18,150 +25,145 @@ import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.exception.LectureAccessDeniedException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LectureCommandServiceImpl implements LectureCommandService {
 
-  private static final String ROLE_MASTER = "MASTER";
-  private final LectureRepository lectureRepository;
+	private static final String ROLE_MASTER = "MASTER";
+	private final LectureRepository lectureRepository;
 
-  @Override
-  public LectureCreateResult createLecture(LectureCreateCommand command) {
-    // Todo: APPROVED 상태 강사만 생성 가능 조건 추가
-    Lecture lecture =
-        Lecture.create(
-            command.instructorId(),
-            command.instructorName(),
-            command.category(),
-            command.title(),
-            command.subtitle(),
-            command.description(),
-            command.durationPolicy(),
-            command.price());
+	@Override
+	public LectureCreateResult createLecture(LectureCreateCommand command) {
+		// Todo: APPROVED 상태 강사만 생성 가능 조건 추가
+		Lecture lecture =
+			Lecture.create(
+				command.instructorId(),
+				command.instructorName(),
+				command.category(),
+				command.title(),
+				command.subtitle(),
+				command.description(),
+				command.durationPolicy(),
+				command.price());
 
-    Lecture saved = lectureRepository.save(lecture);
-    return LectureCreateResult.from(saved);
-  }
+		Lecture saved = lectureRepository.save(lecture);
+		return LectureCreateResult.from(saved);
+	}
 
-  @Override
-  @Transactional
-  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-    Lecture lecture =
-        lectureRepository
-            .findById(command.lectureId())
-            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+	@Override
+	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    UUID chapterId =
-        lecture.addChapter(
-            command.title(), command.content(), command.sortOrder(), command.durationSeconds());
+		UUID chapterId =
+			lecture.addChapter(
+				command.title(), command.content(), command.sortOrder(), command.durationSeconds());
 
-    return ChapterCreateResult.from(lecture.getId(), chapterId);
-  }
+		return ChapterCreateResult.from(lecture.getId(), chapterId);
+	}
 
-  @Override
-  public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
-    Lecture lecture =
-        lectureRepository
-            .findById(command.lectureId())
-            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+	@Override
+	public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    validateLectureAccess(lecture, command.actorId(), command.actorRole());
+		validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-    lecture.updateMetadata(
-        command.title(),
-        command.subtitle(),
-        command.description(),
-        command.category(),
-        command.durationPolicy(),
-        command.price());
+		lecture.updateMetadata(
+			command.title(),
+			command.subtitle(),
+			command.description(),
+			command.category(),
+			command.durationPolicy(),
+			command.price());
 
-    return LectureUpdateResult.from(lecture);
-  }
+		return LectureUpdateResult.from(lecture);
+	}
 
-  @Override
-  public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
-    Lecture lecture =
-        lectureRepository
-            .findById(command.lectureId())
-            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+	@Override
+	public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    validateLectureAccess(lecture, command.actorId(), command.actorRole());
+		validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-    lecture.delete(command.actorId());
+		lecture.delete(command.actorId());
 
-    return LectureDeleteResult.from(command.lectureId());
-  }
+		return LectureDeleteResult.from(command.lectureId());
+	}
 
-  @Override
-  public ChapterUpdateResult updateChapter(ChapterUpdateCommand command) {
-    Lecture lecture =
-        lectureRepository
-            .findById(command.lectureId())
-            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+	@Override
+	public ChapterUpdateResult updateChapter(ChapterUpdateCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    validateLectureAccess(lecture, command.actorId(), command.actorRole());
+		validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-    lecture.updateChapter(
-        command.chapterId(), command.title(), command.content(), command.durationSeconds());
+		lecture.updateChapter(
+			command.chapterId(), command.title(), command.content(), command.durationSeconds());
 
-    return ChapterUpdateResult.from(lecture.getId(), command.chapterId());
-  }
+		return ChapterUpdateResult.from(lecture.getId(), command.chapterId());
+	}
 
-  @Override
-  public ChapterDeleteResult deleteChapter(ChapterDeleteCommand command) {
-    Lecture lecture =
-        lectureRepository
-            .findById(command.lectureId())
-            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+	@Override
+	public ChapterDeleteResult deleteChapter(ChapterDeleteCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    validateLectureAccess(lecture, command.actorId(), command.actorRole());
+		validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-    lecture.removeChapter(command.chapterId());
+		lecture.removeChapter(command.chapterId());
 
-    return ChapterDeleteResult.from(command.lectureId(), command.chapterId());
-  }
+		return ChapterDeleteResult.from(command.lectureId(), command.chapterId());
+	}
 
-  @Override
-  public ChapterReorderResult reorderChapters(ChapterReorderCommand command) {
-    Lecture lecture =
-        lectureRepository
-            .findById(command.lectureId())
-            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+	@Override
+	public ChapterReorderResult reorderChapters(ChapterReorderCommand command) {
+		Lecture lecture =
+			lectureRepository
+				.findById(command.lectureId())
+				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-    validateLectureAccess(lecture, command.actorId(), command.actorRole());
+		validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-    Map<UUID, Integer> chapterOrders =
-        command.orders().stream()
-            .collect(
-                Collectors.toMap(
-                    ChapterReorderCommand.ChapterOrderCommand::chapterId,
-                    ChapterReorderCommand.ChapterOrderCommand::sortOrder));
+		Map<UUID, Integer> chapterOrders =
+			command.orders().stream()
+				.collect(
+					Collectors.toMap(
+						ChapterReorderCommand.ChapterOrderCommand::chapterId,
+						ChapterReorderCommand.ChapterOrderCommand::sortOrder));
 
-    lecture.reorderChapters(chapterOrders);
+		lecture.reorderChapters(chapterOrders);
 
-    return ChapterReorderResult.from(command.lectureId());
-  }
+		return ChapterReorderResult.from(command.lectureId());
+	}
 
-  // 강의 소유자(강사) 또는 관리자(MASTER)만 통과
-  private void validateLectureAccess(Lecture lecture, UUID actorId, String actorRole) {
-    if (lecture.isOwnedBy(actorId) || isAdmin(actorRole)) {
-      return;
-    }
-    throw new LectureAccessDeniedException();
-  }
+	// 강의 소유자(강사) 또는 관리자(MASTER)만 통과
+	private void validateLectureAccess(Lecture lecture, UUID actorId, String actorRole) {
+		if (lecture.isOwnedBy(actorId) || isAdmin(actorRole)) {
+			return;
+		}
+		throw new LectureAccessDeniedException();
+	}
 
-  private boolean isAdmin(String actorRole) {
-    // TODO(#로그인): user-service 로그인 API 연동 후 공통 UserRole enum 으로 교체
-    //   위에 상수도 제거
-    // return actorRole == UserRole.MASTER;
-    return ROLE_MASTER.equals(actorRole);
-  }
+	private boolean isAdmin(String actorRole) {
+		// TODO(#로그인): user-service 로그인 API 연동 후 공통 UserRole enum 으로 교체
+		//   위에 상수도 제거
+		// return actorRole == UserRole.MASTER;
+		return ROLE_MASTER.equals(actorRole);
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/command/service/LectureCommandServiceImpl.java
@@ -1,12 +1,5 @@
 package com.goggles.lecture_service.application.lecture.command.service;
 
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteCommand;
@@ -25,145 +18,149 @@ import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.exception.LectureAccessDeniedException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LectureCommandServiceImpl implements LectureCommandService {
 
-	private static final String ROLE_MASTER = "MASTER";
-	private final LectureRepository lectureRepository;
+  private static final String ROLE_MASTER = "MASTER";
+  private final LectureRepository lectureRepository;
 
-	@Override
-	public LectureCreateResult createLecture(LectureCreateCommand command) {
-		// Todo: APPROVED 상태 강사만 생성 가능 조건 추가
-		Lecture lecture =
-			Lecture.create(
-				command.instructorId(),
-				command.instructorName(),
-				command.category(),
-				command.title(),
-				command.subtitle(),
-				command.description(),
-				command.durationPolicy(),
-				command.price());
+  @Override
+  public LectureCreateResult createLecture(LectureCreateCommand command) {
+    // Todo: APPROVED 상태 강사만 생성 가능 조건 추가
+    Lecture lecture =
+        Lecture.create(
+            command.instructorId(),
+            command.instructorName(),
+            command.category(),
+            command.title(),
+            command.subtitle(),
+            command.description(),
+            command.durationPolicy(),
+            command.price());
 
-		Lecture saved = lectureRepository.save(lecture);
-		return LectureCreateResult.from(saved);
-	}
+    Lecture saved = lectureRepository.save(lecture);
+    return LectureCreateResult.from(saved);
+  }
 
-	@Override
-	public ChapterCreateResult createChapter(ChapterCreateCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  public ChapterCreateResult createChapter(ChapterCreateCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		UUID chapterId =
-			lecture.addChapter(
-				command.title(), command.content(), command.sortOrder(), command.durationSeconds());
+    UUID chapterId =
+        lecture.addChapter(
+            command.title(), command.content(), command.sortOrder(), command.durationSeconds());
 
-		return ChapterCreateResult.from(lecture.getId(), chapterId);
-	}
+    return ChapterCreateResult.from(lecture.getId(), chapterId);
+  }
 
-	@Override
-	public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  public LectureUpdateResult updateLecture(LectureUpdateCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-		lecture.updateMetadata(
-			command.title(),
-			command.subtitle(),
-			command.description(),
-			command.category(),
-			command.durationPolicy(),
-			command.price());
+    lecture.updateMetadata(
+        command.title(),
+        command.subtitle(),
+        command.description(),
+        command.category(),
+        command.durationPolicy(),
+        command.price());
 
-		return LectureUpdateResult.from(lecture);
-	}
+    return LectureUpdateResult.from(lecture);
+  }
 
-	@Override
-	public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  public LectureDeleteResult deleteLecture(LectureDeleteCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-		lecture.delete(command.actorId());
+    lecture.delete(command.actorId());
 
-		return LectureDeleteResult.from(command.lectureId());
-	}
+    return LectureDeleteResult.from(command.lectureId());
+  }
 
-	@Override
-	public ChapterUpdateResult updateChapter(ChapterUpdateCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  public ChapterUpdateResult updateChapter(ChapterUpdateCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-		lecture.updateChapter(
-			command.chapterId(), command.title(), command.content(), command.durationSeconds());
+    lecture.updateChapter(
+        command.chapterId(), command.title(), command.content(), command.durationSeconds());
 
-		return ChapterUpdateResult.from(lecture.getId(), command.chapterId());
-	}
+    return ChapterUpdateResult.from(lecture.getId(), command.chapterId());
+  }
 
-	@Override
-	public ChapterDeleteResult deleteChapter(ChapterDeleteCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  public ChapterDeleteResult deleteChapter(ChapterDeleteCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-		lecture.removeChapter(command.chapterId());
+    lecture.removeChapter(command.chapterId());
 
-		return ChapterDeleteResult.from(command.lectureId(), command.chapterId());
-	}
+    return ChapterDeleteResult.from(command.lectureId(), command.chapterId());
+  }
 
-	@Override
-	public ChapterReorderResult reorderChapters(ChapterReorderCommand command) {
-		Lecture lecture =
-			lectureRepository
-				.findById(command.lectureId())
-				.orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
+  @Override
+  public ChapterReorderResult reorderChapters(ChapterReorderCommand command) {
+    Lecture lecture =
+        lectureRepository
+            .findById(command.lectureId())
+            .orElseThrow(() -> new LectureNotFoundException(command.lectureId()));
 
-		validateLectureAccess(lecture, command.actorId(), command.actorRole());
+    validateLectureAccess(lecture, command.actorId(), command.actorRole());
 
-		Map<UUID, Integer> chapterOrders =
-			command.orders().stream()
-				.collect(
-					Collectors.toMap(
-						ChapterReorderCommand.ChapterOrderCommand::chapterId,
-						ChapterReorderCommand.ChapterOrderCommand::sortOrder));
+    Map<UUID, Integer> chapterOrders =
+        command.orders().stream()
+            .collect(
+                Collectors.toMap(
+                    ChapterReorderCommand.ChapterOrderCommand::chapterId,
+                    ChapterReorderCommand.ChapterOrderCommand::sortOrder));
 
-		lecture.reorderChapters(chapterOrders);
+    lecture.reorderChapters(chapterOrders);
 
-		return ChapterReorderResult.from(command.lectureId());
-	}
+    return ChapterReorderResult.from(command.lectureId());
+  }
 
-	// 강의 소유자(강사) 또는 관리자(MASTER)만 통과
-	private void validateLectureAccess(Lecture lecture, UUID actorId, String actorRole) {
-		if (lecture.isOwnedBy(actorId) || isAdmin(actorRole)) {
-			return;
-		}
-		throw new LectureAccessDeniedException();
-	}
+  // 강의 소유자(강사) 또는 관리자(MASTER)만 통과
+  private void validateLectureAccess(Lecture lecture, UUID actorId, String actorRole) {
+    if (lecture.isOwnedBy(actorId) || isAdmin(actorRole)) {
+      return;
+    }
+    throw new LectureAccessDeniedException();
+  }
 
-	private boolean isAdmin(String actorRole) {
-		// TODO(#로그인): user-service 로그인 API 연동 후 공통 UserRole enum 으로 교체
-		//   위에 상수도 제거
-		// return actorRole == UserRole.MASTER;
-		return ROLE_MASTER.equals(actorRole);
-	}
+  private boolean isAdmin(String actorRole) {
+    // TODO(#로그인): user-service 로그인 API 연동 후 공통 UserRole enum 으로 교체
+    //   위에 상수도 제거
+    // return actorRole == UserRole.MASTER;
+    return ROLE_MASTER.equals(actorRole);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/query/dto/ChapterDetail.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/query/dto/ChapterDetail.java
@@ -1,17 +1,13 @@
 package com.goggles.lecture_service.application.lecture.query.dto;
 
-import com.goggles.lecture_service.domain.lecture.Chapter;
+import com.goggles.lecture_service.domain.lecture.ChapterView;
 import java.util.UUID;
 
 public record ChapterDetail(
     UUID id, String title, String content, int sortOrder, int durationSeconds) {
 
-  public static ChapterDetail from(Chapter chapter) {
+  public static ChapterDetail from(ChapterView view) {
     return new ChapterDetail(
-        chapter.getId(),
-        chapter.getContent().getTitle(),
-        chapter.getContent().getContent(),
-        chapter.getSortOrder(),
-        chapter.getDuration().getSeconds());
+        view.id(), view.title(), view.content(), view.sortOrder(), view.durationSeconds());
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/query/dto/LectureDetail.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/query/dto/LectureDetail.java
@@ -33,6 +33,6 @@ public record LectureDetail(
         lecture.getDurationPolicy(),
         lecture.getStatus(),
         lecture.getRejectionReason(),
-        lecture.getChapters().stream().map(ChapterDetail::from).toList());
+        lecture.getChapterViews().stream().map(ChapterDetail::from).toList());
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterView.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/ChapterView.java
@@ -1,0 +1,16 @@
+package com.goggles.lecture_service.domain.lecture;
+
+import java.util.UUID;
+
+public record ChapterView(
+    UUID id, String title, String content, int sortOrder, int durationSeconds) {
+
+  public static ChapterView from(Chapter chapter) {
+    return new ChapterView(
+        chapter.getId(),
+        chapter.getContent().getTitle(),
+        chapter.getContent().getContent(),
+        chapter.getSortOrder(),
+        chapter.getDuration().getSeconds());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,5 +1,14 @@
 package com.goggles.lecture_service.domain.lecture;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.hibernate.annotations.SQLRestriction;
+
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
@@ -10,6 +19,7 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldE
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -19,14 +29,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -35,204 +40,247 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-  @Id
-  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
-  private UUID id = UUID.randomUUID();
+	@Id
+	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
+	private UUID id = UUID.randomUUID();
 
-  @Embedded private Instructor instructor;
+	@Embedded
+	private Instructor instructor;
 
-  @Column(nullable = false, length = 50)
-  private String category;
+	@Column(nullable = false, length = 50)
+	private String category;
 
-  @Embedded private LectureContent content;
+	@Embedded
+	private LectureContent content;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private DurationPolicy durationPolicy;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private DurationPolicy durationPolicy;
 
-  @Embedded private Money price;
+	@Embedded
+	private Money price;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 20)
-  private LectureStatus status;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private LectureStatus status;
 
-  @Column(columnDefinition = "TEXT")
-  private String rejectionReason;
+	@Column(columnDefinition = "TEXT")
+	private String rejectionReason;
 
-  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Chapter> chapters = new ArrayList<>();
+	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Chapter> chapters = new ArrayList<>();
 
-  // 정적 팩토리 메서드
-  public static Lecture create(
-      UUID instructorId,
-      String instructorName,
-      String category,
-      String title,
-      String subtitle,
-      String description,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
+	// 정적 팩토리 메서드
+	public static Lecture create(
+		UUID instructorId,
+		String instructorName,
+		String category,
+		String title,
+		String subtitle,
+		String description,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
 
-    validateCategory(category);
+		validateCategory(category);
 
-    return new Lecture(
-        new Instructor(instructorId, instructorName),
-        category,
-        new LectureContent(title, subtitle, description),
-        durationPolicy,
-        Money.of(priceAmount));
-  }
+		return new Lecture(
+			new Instructor(instructorId, instructorName),
+			category,
+			new LectureContent(title, subtitle, description),
+			durationPolicy,
+			Money.of(priceAmount));
+	}
 
-  private Lecture(
-      Instructor instructor,
-      String category,
-      LectureContent content,
-      DurationPolicy durationPolicy,
-      Money price) {
-    this.instructor = instructor;
-    this.category = category;
-    this.content = content;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = price;
-    this.status = LectureStatus.DRAFT;
-  }
+	private Lecture(
+		Instructor instructor,
+		String category,
+		LectureContent content,
+		DurationPolicy durationPolicy,
+		Money price) {
+		this.instructor = instructor;
+		this.category = category;
+		this.content = content;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = price;
+		this.status = LectureStatus.DRAFT;
+	}
 
-  // 도메인 메서드 (챕터 관리)
-  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
-    validateDraftStatus();
-    validateDuplicateSortOrder(sortOrder);
+	// 도메인 메서드 (챕터 관리)
+	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
+		validateDraftStatus();
+		validateDuplicateSortOrder(sortOrder);
 
-    ChapterContent chapterContent = new ChapterContent(title, content);
-    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+		ChapterContent chapterContent = new ChapterContent(title, content);
+		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-    chapters.add(chapter);
+		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+		chapters.add(chapter);
 
-    return chapter.getId();
-  }
+		return chapter.getId();
+	}
 
-  public void removeChapter(UUID chapterId) {
-    validateDraftStatus();
-    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-    if (!removed) {
-      throw new ChapterNotFoundException(chapterId);
-    }
-  }
+	public void removeChapter(UUID chapterId) {
+		validateDraftStatus();
+		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+		if (!removed) {
+			throw new ChapterNotFoundException(chapterId);
+		}
+	}
 
-  public void reorderChapter(UUID chapterId, int newSortOrder) {
-    validateDraftStatus();
-    Chapter target = findChapterById(chapterId);
-    if (target.getSortOrder() == newSortOrder) return;
-    validateDuplicateSortOrder(newSortOrder);
-    target.updateSortOrder(newSortOrder);
-  }
+	// 챕터 수정 (DRAFT 상태에서만, 순서는 변경하지 않음)
+	public void updateChapter(UUID chapterId, String title, String content, int durationSeconds) {
+		validateDraftStatus();
 
-  public List<Chapter> getChapters() {
-    return Collections.unmodifiableList(chapters);
-  }
+		Chapter target = findChapterById(chapterId);
 
-  // 도메인 메서드 (정보 수정)
-  public void updateMetadata(
-      String title,
-      String subtitle,
-      String description,
-      String category,
-      DurationPolicy durationPolicy,
-      Long priceAmount) {
-    validateDraftStatus();
-    validateCategory(category);
+		target.updateContent(new ChapterContent(title, content));
+		target.updateDuration(new ChapterDuration(durationSeconds));
+	}
 
-    this.content = new LectureContent(title, subtitle, description);
-    this.category = category;
-    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-    this.price = Money.of(priceAmount);
-  }
+	// 챕터 일괄 순서 변경 (DRAFT 상태에서만) 변경 후 sortOrder가 강의 전체 챕터 안에서 중복되면 throw
+	public void reorderChapters(Map<UUID, Integer> chapterOrders) {
+		validateDraftStatus();
 
-  // 도메인 메서드 (상태 전이)
-  public void submitForReview() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    if (chapters.isEmpty()) {
-      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-    }
-    this.status = LectureStatus.PENDING_REVIEW;
-    // 리뷰 재신청 시 이전 이유 삭제
-    this.rejectionReason = null;
-  }
+		Map<UUID, Chapter> chapterMap =
+			chapters.stream().collect(Collectors.toMap(Chapter::getId, chapter -> chapter));
 
-  // 도메인 메서드 (삭제)
-  public void delete(UUID deletedBy) {
-    if (deletedBy == null) {
-      throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
-    }
-    validateDraftStatus();
-    softDelete(deletedBy);
-  }
+		// 1. 모든 chapterId 이 강의의 챕터인지 검증
+		for (UUID chapterId : chapterOrders.keySet()) {
+			if (!chapterMap.containsKey(chapterId)) {
+				throw new ChapterNotFoundException(chapterId);
+			}
+		}
 
-  public void approve() {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    this.status = LectureStatus.PUBLISHED;
-    this.rejectionReason = null;
-  }
+		// 2. 변경 후 최종 sortOrder 중복 확인
+		Map<UUID, Integer> finalSortOrders =
+			chapters.stream().collect(Collectors.toMap(Chapter::getId, Chapter::getSortOrder));
+		chapterOrders.forEach(finalSortOrders::put);
 
-  public void reject(String reason) {
-    if (this.status != LectureStatus.PENDING_REVIEW) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    if (reason == null || reason.isBlank()) {
-      throw new InvalidRejectionReasonException();
-    }
-    this.status = LectureStatus.DRAFT;
-    this.rejectionReason = reason;
-  }
+		Integer duplicatedSortOrder =
+			finalSortOrders.values().stream()
+				.collect(Collectors.groupingBy(sortOrder -> sortOrder, Collectors.counting()))
+				.entrySet()
+				.stream()
+				.filter(entry -> entry.getValue() > 1)
+				.map(Map.Entry::getKey)
+				.findFirst()
+				.orElse(null);
 
-  public void hide() {
-    if (this.status != LectureStatus.PUBLISHED) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-    this.status = LectureStatus.HIDDEN;
-  }
+		if (duplicatedSortOrder != null) {
+			throw new DuplicateSortOrderException(duplicatedSortOrder);
+		}
 
-  // 도메인 메서드 (소유자 확인)
-  public boolean isOwnedBy(UUID userId) {
-    if (userId == null || this.instructor == null) {
-      return false;
-    }
-    return userId.equals(this.instructor.getInstructorId());
-  }
+		// 3) 적용
+		chapterOrders.forEach(
+			(chapterId, sortOrder) -> chapterMap.get(chapterId).updateSortOrder(sortOrder));
+	}
 
-  // 주문 가능 여부
-  public boolean isOrderable() {
-    return this.status == LectureStatus.PUBLISHED;
-  }
+	public List<Chapter> getChapters() {
+		return Collections.unmodifiableList(chapters);
+	}
 
-  // 내부 검증 및 편의 메서드
-  private void validateDraftStatus() {
-    if (this.status != LectureStatus.DRAFT) {
-      throw new InvalidLectureStatusException(id, status);
-    }
-  }
+	// 도메인 메서드 (정보 수정)
+	public void updateMetadata(
+		String title,
+		String subtitle,
+		String description,
+		String category,
+		DurationPolicy durationPolicy,
+		Long priceAmount) {
+		validateDraftStatus();
+		validateCategory(category);
 
-  private void validateDuplicateSortOrder(int sortOrder) {
-    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-    if (isDuplicate) {
-      throw new DuplicateSortOrderException(sortOrder);
-    }
-  }
+		this.content = new LectureContent(title, subtitle, description);
+		this.category = category;
+		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+		this.price = Money.of(priceAmount);
+	}
 
-  private Chapter findChapterById(UUID chapterId) {
-    return chapters.stream()
-        .filter(c -> c.getId().equals(chapterId))
-        .findFirst()
-        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
-  }
+	// 도메인 메서드 (상태 전이)
+	public void submitForReview() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (chapters.isEmpty()) {
+			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
+		}
+		this.status = LectureStatus.PENDING_REVIEW;
+		// 리뷰 재신청 시 이전 이유 삭제
+		this.rejectionReason = null;
+	}
 
-  private static void validateCategory(String category) {
-    if (category == null || category.isBlank()) {
-      throw new InvalidCategoryException();
-    }
-  }
+	// 도메인 메서드 (삭제)
+	public void delete(UUID deletedBy) {
+		if (deletedBy == null) {
+			throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+		}
+		validateDraftStatus();
+		softDelete(deletedBy);
+	}
+
+	public void approve() {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.PUBLISHED;
+		this.rejectionReason = null;
+	}
+
+	public void reject(String reason) {
+		if (this.status != LectureStatus.PENDING_REVIEW) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		if (reason == null || reason.isBlank()) {
+			throw new InvalidRejectionReasonException();
+		}
+		this.status = LectureStatus.DRAFT;
+		this.rejectionReason = reason;
+	}
+
+	public void hide() {
+		if (this.status != LectureStatus.PUBLISHED) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+		this.status = LectureStatus.HIDDEN;
+	}
+
+	// 도메인 메서드 (소유자 확인)
+	public boolean isOwnedBy(UUID userId) {
+		if (userId == null || this.instructor == null) {
+			return false;
+		}
+		return userId.equals(this.instructor.getInstructorId());
+	}
+
+	// 주문 가능 여부
+	public boolean isOrderable() {
+		return this.status == LectureStatus.PUBLISHED;
+	}
+
+	// 내부 검증 및 편의 메서드
+	private void validateDraftStatus() {
+		if (this.status != LectureStatus.DRAFT) {
+			throw new InvalidLectureStatusException(id, status);
+		}
+	}
+
+	private void validateDuplicateSortOrder(int sortOrder) {
+		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+		if (isDuplicate) {
+			throw new DuplicateSortOrderException(sortOrder);
+		}
+	}
+
+	private Chapter findChapterById(UUID chapterId) {
+		return chapters.stream()
+			.filter(c -> c.getId().equals(chapterId))
+			.findFirst()
+			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
+	}
+
+	private static void validateCategory(String category) {
+		if (category == null || category.isBlank()) {
+			throw new InvalidCategoryException();
+		}
+	}
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/Lecture.java
@@ -1,14 +1,5 @@
 package com.goggles.lecture_service.domain.lecture;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.hibernate.annotations.SQLRestriction;
-
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
@@ -19,7 +10,6 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldE
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatusException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidRejectionReasonException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureErrorCode;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -29,9 +19,15 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_lecture")
@@ -40,247 +36,257 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseAudit {
 
-	@Id
-	@Column(columnDefinition = "uuid", updatable = false, nullable = false)
-	private UUID id = UUID.randomUUID();
+  @Id
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id = UUID.randomUUID();
 
-	@Embedded
-	private Instructor instructor;
+  @Embedded private Instructor instructor;
 
-	@Column(nullable = false, length = 50)
-	private String category;
+  @Column(nullable = false, length = 50)
+  private String category;
 
-	@Embedded
-	private LectureContent content;
+  @Embedded private LectureContent content;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private DurationPolicy durationPolicy;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private DurationPolicy durationPolicy;
 
-	@Embedded
-	private Money price;
+  @Embedded private Money price;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, length = 20)
-	private LectureStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private LectureStatus status;
 
-	@Column(columnDefinition = "TEXT")
-	private String rejectionReason;
+  @Column(columnDefinition = "TEXT")
+  private String rejectionReason;
 
-	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Chapter> chapters = new ArrayList<>();
+  @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Chapter> chapters = new ArrayList<>();
 
-	// 정적 팩토리 메서드
-	public static Lecture create(
-		UUID instructorId,
-		String instructorName,
-		String category,
-		String title,
-		String subtitle,
-		String description,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
+  // 정적 팩토리 메서드
+  public static Lecture create(
+      UUID instructorId,
+      String instructorName,
+      String category,
+      String title,
+      String subtitle,
+      String description,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
 
-		validateCategory(category);
+    validateCategory(category);
 
-		return new Lecture(
-			new Instructor(instructorId, instructorName),
-			category,
-			new LectureContent(title, subtitle, description),
-			durationPolicy,
-			Money.of(priceAmount));
-	}
+    return new Lecture(
+        new Instructor(instructorId, instructorName),
+        category,
+        new LectureContent(title, subtitle, description),
+        durationPolicy,
+        Money.of(priceAmount));
+  }
 
-	private Lecture(
-		Instructor instructor,
-		String category,
-		LectureContent content,
-		DurationPolicy durationPolicy,
-		Money price) {
-		this.instructor = instructor;
-		this.category = category;
-		this.content = content;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = price;
-		this.status = LectureStatus.DRAFT;
-	}
+  private Lecture(
+      Instructor instructor,
+      String category,
+      LectureContent content,
+      DurationPolicy durationPolicy,
+      Money price) {
+    this.instructor = instructor;
+    this.category = category;
+    this.content = content;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = price;
+    this.status = LectureStatus.DRAFT;
+  }
 
-	// 도메인 메서드 (챕터 관리)
-	public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
-		validateDraftStatus();
-		validateDuplicateSortOrder(sortOrder);
+  // 도메인 메서드 (챕터 관리)
+  public UUID addChapter(String title, String content, int sortOrder, int durationSeconds) {
+    validateDraftStatus();
+    validateDuplicateSortOrder(sortOrder);
 
-		ChapterContent chapterContent = new ChapterContent(title, content);
-		ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
+    ChapterContent chapterContent = new ChapterContent(title, content);
+    ChapterDuration chapterDuration = new ChapterDuration(durationSeconds);
 
-		Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
-		chapters.add(chapter);
+    Chapter chapter = Chapter.create(this, chapterContent, sortOrder, chapterDuration);
+    chapters.add(chapter);
 
-		return chapter.getId();
-	}
+    return chapter.getId();
+  }
 
-	public void removeChapter(UUID chapterId) {
-		validateDraftStatus();
-		boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
-		if (!removed) {
-			throw new ChapterNotFoundException(chapterId);
-		}
-	}
+  public void removeChapter(UUID chapterId) {
+    validateDraftStatus();
+    boolean removed = chapters.removeIf(chapter -> chapter.getId().equals(chapterId));
+    if (!removed) {
+      throw new ChapterNotFoundException(chapterId);
+    }
+  }
 
-	// 챕터 수정 (DRAFT 상태에서만, 순서는 변경하지 않음)
-	public void updateChapter(UUID chapterId, String title, String content, int durationSeconds) {
-		validateDraftStatus();
+  // 챕터 수정 (DRAFT 상태에서만, 순서는 변경하지 않음)
+  public void updateChapter(UUID chapterId, String title, String content, int durationSeconds) {
+    validateDraftStatus();
 
-		Chapter target = findChapterById(chapterId);
+    Chapter target = findChapterById(chapterId);
 
-		target.updateContent(new ChapterContent(title, content));
-		target.updateDuration(new ChapterDuration(durationSeconds));
-	}
+    target.updateContent(new ChapterContent(title, content));
+    target.updateDuration(new ChapterDuration(durationSeconds));
+  }
 
-	// 챕터 일괄 순서 변경 (DRAFT 상태에서만) 변경 후 sortOrder가 강의 전체 챕터 안에서 중복되면 throw
-	public void reorderChapters(Map<UUID, Integer> chapterOrders) {
-		validateDraftStatus();
+  // 챕터 일괄 순서 변경 (DRAFT 상태에서만) 변경 후 sortOrder가 강의 전체 챕터 안에서 중복되면 throw
+  public void reorderChapters(Map<UUID, Integer> chapterOrders) {
+    validateDraftStatus();
 
-		Map<UUID, Chapter> chapterMap =
-			chapters.stream().collect(Collectors.toMap(Chapter::getId, chapter -> chapter));
+    Map<UUID, Chapter> chapterMap =
+        chapters.stream().collect(Collectors.toMap(Chapter::getId, chapter -> chapter));
 
-		// 1. 모든 chapterId 이 강의의 챕터인지 검증
-		for (UUID chapterId : chapterOrders.keySet()) {
-			if (!chapterMap.containsKey(chapterId)) {
-				throw new ChapterNotFoundException(chapterId);
-			}
-		}
+    // 1. 모든 chapterId 이 강의의 챕터인지 검증
+    for (UUID chapterId : chapterOrders.keySet()) {
+      if (!chapterMap.containsKey(chapterId)) {
+        throw new ChapterNotFoundException(chapterId);
+      }
+    }
 
-		// 2. 변경 후 최종 sortOrder 중복 확인
-		Map<UUID, Integer> finalSortOrders =
-			chapters.stream().collect(Collectors.toMap(Chapter::getId, Chapter::getSortOrder));
-		chapterOrders.forEach(finalSortOrders::put);
+    // 2. 변경 후 최종 sortOrder 중복 확인
+    Map<UUID, Integer> finalSortOrders =
+        chapters.stream().collect(Collectors.toMap(Chapter::getId, Chapter::getSortOrder));
+    chapterOrders.forEach(finalSortOrders::put);
 
-		Integer duplicatedSortOrder =
-			finalSortOrders.values().stream()
-				.collect(Collectors.groupingBy(sortOrder -> sortOrder, Collectors.counting()))
-				.entrySet()
-				.stream()
-				.filter(entry -> entry.getValue() > 1)
-				.map(Map.Entry::getKey)
-				.findFirst()
-				.orElse(null);
+    Integer duplicatedSortOrder =
+        finalSortOrders.values().stream()
+            .collect(Collectors.groupingBy(sortOrder -> sortOrder, Collectors.counting()))
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getValue() > 1)
+            .map(Map.Entry::getKey)
+            .findFirst()
+            .orElse(null);
 
-		if (duplicatedSortOrder != null) {
-			throw new DuplicateSortOrderException(duplicatedSortOrder);
-		}
+    if (duplicatedSortOrder != null) {
+      throw new DuplicateSortOrderException(duplicatedSortOrder);
+    }
 
-		// 3) 적용
-		chapterOrders.forEach(
-			(chapterId, sortOrder) -> chapterMap.get(chapterId).updateSortOrder(sortOrder));
-	}
+    // 3) 적용
+    chapterOrders.forEach(
+        (chapterId, sortOrder) -> chapterMap.get(chapterId).updateSortOrder(sortOrder));
+  }
 
-	public List<Chapter> getChapters() {
-		return Collections.unmodifiableList(chapters);
-	}
+  public List<ChapterView> getChapterViews() {
+    return chapters.stream()
+        .map(
+            chapter ->
+                new ChapterView(
+                    chapter.getId(),
+                    chapter.getContent().getTitle(),
+                    chapter.getContent().getContent(),
+                    chapter.getSortOrder(),
+                    chapter.getDuration().getSeconds()))
+        .toList();
+  }
 
-	// 도메인 메서드 (정보 수정)
-	public void updateMetadata(
-		String title,
-		String subtitle,
-		String description,
-		String category,
-		DurationPolicy durationPolicy,
-		Long priceAmount) {
-		validateDraftStatus();
-		validateCategory(category);
+  public int getChapterCount() {
+    return chapters.size();
+  }
 
-		this.content = new LectureContent(title, subtitle, description);
-		this.category = category;
-		this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
-		this.price = Money.of(priceAmount);
-	}
+  // 도메인 메서드 (정보 수정)
+  public void updateMetadata(
+      String title,
+      String subtitle,
+      String description,
+      String category,
+      DurationPolicy durationPolicy,
+      Long priceAmount) {
+    validateDraftStatus();
+    validateCategory(category);
 
-	// 도메인 메서드 (상태 전이)
-	public void submitForReview() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (chapters.isEmpty()) {
-			throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
-		}
-		this.status = LectureStatus.PENDING_REVIEW;
-		// 리뷰 재신청 시 이전 이유 삭제
-		this.rejectionReason = null;
-	}
+    this.content = new LectureContent(title, subtitle, description);
+    this.category = category;
+    this.durationPolicy = durationPolicy != null ? durationPolicy : DurationPolicy.DAYS_365;
+    this.price = Money.of(priceAmount);
+  }
 
-	// 도메인 메서드 (삭제)
-	public void delete(UUID deletedBy) {
-		if (deletedBy == null) {
-			throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
-		}
-		validateDraftStatus();
-		softDelete(deletedBy);
-	}
+  // 도메인 메서드 (상태 전이)
+  public void submitForReview() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (chapters.isEmpty()) {
+      throw new InvalidLectureFieldException(LectureErrorCode.LECTURE_CHAPTER_REQUIRED);
+    }
+    this.status = LectureStatus.PENDING_REVIEW;
+    // 리뷰 재신청 시 이전 이유 삭제
+    this.rejectionReason = null;
+  }
 
-	public void approve() {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.PUBLISHED;
-		this.rejectionReason = null;
-	}
+  // 도메인 메서드 (삭제)
+  public void delete(UUID deletedBy) {
+    if (deletedBy == null) {
+      throw new InvalidLectureFieldException(LectureErrorCode.USER_ID_REQUIRED);
+    }
+    validateDraftStatus();
+    softDelete(deletedBy);
+  }
 
-	public void reject(String reason) {
-		if (this.status != LectureStatus.PENDING_REVIEW) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		if (reason == null || reason.isBlank()) {
-			throw new InvalidRejectionReasonException();
-		}
-		this.status = LectureStatus.DRAFT;
-		this.rejectionReason = reason;
-	}
+  public void approve() {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.PUBLISHED;
+    this.rejectionReason = null;
+  }
 
-	public void hide() {
-		if (this.status != LectureStatus.PUBLISHED) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-		this.status = LectureStatus.HIDDEN;
-	}
+  public void reject(String reason) {
+    if (this.status != LectureStatus.PENDING_REVIEW) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new InvalidRejectionReasonException();
+    }
+    this.status = LectureStatus.DRAFT;
+    this.rejectionReason = reason;
+  }
 
-	// 도메인 메서드 (소유자 확인)
-	public boolean isOwnedBy(UUID userId) {
-		if (userId == null || this.instructor == null) {
-			return false;
-		}
-		return userId.equals(this.instructor.getInstructorId());
-	}
+  public void hide() {
+    if (this.status != LectureStatus.PUBLISHED) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+    this.status = LectureStatus.HIDDEN;
+  }
 
-	// 주문 가능 여부
-	public boolean isOrderable() {
-		return this.status == LectureStatus.PUBLISHED;
-	}
+  // 도메인 메서드 (소유자 확인)
+  public boolean isOwnedBy(UUID userId) {
+    if (userId == null || this.instructor == null) {
+      return false;
+    }
+    return userId.equals(this.instructor.getInstructorId());
+  }
 
-	// 내부 검증 및 편의 메서드
-	private void validateDraftStatus() {
-		if (this.status != LectureStatus.DRAFT) {
-			throw new InvalidLectureStatusException(id, status);
-		}
-	}
+  // 주문 가능 여부
+  public boolean isOrderable() {
+    return this.status == LectureStatus.PUBLISHED;
+  }
 
-	private void validateDuplicateSortOrder(int sortOrder) {
-		boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
-		if (isDuplicate) {
-			throw new DuplicateSortOrderException(sortOrder);
-		}
-	}
+  // 내부 검증 및 편의 메서드
+  private void validateDraftStatus() {
+    if (this.status != LectureStatus.DRAFT) {
+      throw new InvalidLectureStatusException(id, status);
+    }
+  }
 
-	private Chapter findChapterById(UUID chapterId) {
-		return chapters.stream()
-			.filter(c -> c.getId().equals(chapterId))
-			.findFirst()
-			.orElseThrow(() -> new ChapterNotFoundException(chapterId));
-	}
+  private void validateDuplicateSortOrder(int sortOrder) {
+    boolean isDuplicate = chapters.stream().anyMatch(c -> c.getSortOrder() == sortOrder);
+    if (isDuplicate) {
+      throw new DuplicateSortOrderException(sortOrder);
+    }
+  }
 
-	private static void validateCategory(String category) {
-		if (category == null || category.isBlank()) {
-			throw new InvalidCategoryException();
-		}
-	}
+  private Chapter findChapterById(UUID chapterId) {
+    return chapters.stream()
+        .filter(c -> c.getId().equals(chapterId))
+        .findFirst()
+        .orElseThrow(() -> new ChapterNotFoundException(chapterId));
+  }
+
+  private static void validateCategory(String category) {
+    if (category == null || category.isBlank()) {
+      throw new InvalidCategoryException();
+    }
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -7,42 +7,47 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum LectureErrorCode {
 
-  // 강의
-  LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
-  LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
-  LECTURE_ACCESS_DENIED("강의에 대한 접근 권한이 없습니다."),
-  LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
-  LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
-  LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
-  LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
-  LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
-  LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
-  LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
+	// 강의
+	LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
+	LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+	LECTURE_ACCESS_DENIED("강의에 대한 접근 권한이 없습니다."),
+	LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
+	LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
+	LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
+	LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
+	LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
+	LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
+	LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
 
-  // 요청 필드 검증
-  USER_ID_REQUIRED("사용자 ID는 필수입니다."),
-  USER_ROLE_REQUIRED("사용자 권한은 필수입니다."),
-  LECTURE_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
+	// 요청 필드 검증
+	USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+	USER_ROLE_REQUIRED("사용자 권한은 필수입니다."),
+	LECTURE_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
 
-  // 챕터
-  CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
-  CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
-  CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
-  CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
-  CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
-  CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
-  CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
-  CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
-  CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
+	// 챕터
+	CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
+	CHAPTER_ID_REQUIRED("챕터 ID는 필수입니다."),
+	CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
+	CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
+	CHAPTER_REORDER_ITEMS_REQUIRED("챕터 순서 변경 목록은 필수입니다."),
+	CHAPTER_REORDER_ITEMS_EMPTY("챕터 순서 변경 목록은 비어 있을 수 없습니다."),
+	CHAPTER_SORT_ORDER_REQUIRED("챕터 순서는 필수입니다."),
+	CHAPTER_ID_DUPLICATED("챕터 ID가 중복될 수 없습니다."),
+	CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
+	CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
+	CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
+	CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
+	CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
+	CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
 
-  // 가격
-  PRICE_REQUIRED("가격은 필수입니다."),
-  PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
+	// 가격
+	PRICE_REQUIRED("가격은 필수입니다."),
+	PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
 
-  // 강사
-  INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
-  INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
-  INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
+	// 강사
+	INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+	INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+	INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
 
-  private final String message;
+	private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/exception/LectureErrorCode.java
@@ -7,47 +7,47 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum LectureErrorCode {
 
-	// 강의
-	LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
-	LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
-	LECTURE_ACCESS_DENIED("강의에 대한 접근 권한이 없습니다."),
-	LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
-	LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
-	LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
-	LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
-	LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
-	LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
-	LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
+  // 강의
+  LECTURE_NOT_FOUND("해당 강의를 찾을 수 없습니다."),
+  LECTURE_ID_REQUIRED("강의 ID는 필수입니다."),
+  LECTURE_ACCESS_DENIED("강의에 대한 접근 권한이 없습니다."),
+  LECTURE_INVALID_STATUS("현재 상태에서 허용되지 않는 작업입니다."),
+  LECTURE_CHAPTER_REQUIRED("챕터가 최소 1개 이상 있어야 합니다."),
+  LECTURE_CATEGORY_REQUIRED("카테고리는 필수입니다."),
+  LECTURE_REJECTION_REASON_REQUIRED("반려 사유는 필수입니다."),
+  LECTURE_TITLE_REQUIRED("강의 제목은 필수입니다."),
+  LECTURE_TITLE_TOO_LONG("강의 제목은 200자 이하여야 합니다."),
+  LECTURE_SUBTITLE_TOO_LONG("강의 부제목은 300자 이하여야 합니다."),
 
-	// 요청 필드 검증
-	USER_ID_REQUIRED("사용자 ID는 필수입니다."),
-	USER_ROLE_REQUIRED("사용자 권한은 필수입니다."),
-	LECTURE_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
+  // 요청 필드 검증
+  USER_ID_REQUIRED("사용자 ID는 필수입니다."),
+  USER_ROLE_REQUIRED("사용자 권한은 필수입니다."),
+  LECTURE_DURATION_POLICY_REQUIRED("수강 기간 정책은 필수입니다."),
 
-	// 챕터
-	CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
-	CHAPTER_ID_REQUIRED("챕터 ID는 필수입니다."),
-	CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
-	CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
-	CHAPTER_REORDER_ITEMS_REQUIRED("챕터 순서 변경 목록은 필수입니다."),
-	CHAPTER_REORDER_ITEMS_EMPTY("챕터 순서 변경 목록은 비어 있을 수 없습니다."),
-	CHAPTER_SORT_ORDER_REQUIRED("챕터 순서는 필수입니다."),
-	CHAPTER_ID_DUPLICATED("챕터 ID가 중복될 수 없습니다."),
-	CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
-	CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
-	CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
-	CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
-	CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
-	CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
+  // 챕터
+  CHAPTER_NOT_FOUND("해당 챕터를 찾을 수 없습니다."),
+  CHAPTER_ID_REQUIRED("챕터 ID는 필수입니다."),
+  CHAPTER_DUPLICATE_SORT_ORDER("이미 존재하는 챕터 순서입니다."),
+  CHAPTER_INVALID_SORT_ORDER("챕터 순서는 1 이상이어야 합니다."),
+  CHAPTER_REORDER_ITEMS_REQUIRED("챕터 순서 변경 목록은 필수입니다."),
+  CHAPTER_REORDER_ITEMS_EMPTY("챕터 순서 변경 목록은 비어 있을 수 없습니다."),
+  CHAPTER_SORT_ORDER_REQUIRED("챕터 순서는 필수입니다."),
+  CHAPTER_ID_DUPLICATED("챕터 ID가 중복될 수 없습니다."),
+  CHAPTER_TITLE_REQUIRED("챕터 제목은 필수입니다."),
+  CHAPTER_TITLE_TOO_LONG("챕터 제목은 200자 이하여야 합니다."),
+  CHAPTER_DURATION_INVALID("영상 길이는 1 이상이어야 합니다."),
+  CHAPTER_LECTURE_REQUIRED("챕터의 강의 정보는 필수입니다."),
+  CHAPTER_CONTENT_REQUIRED("챕터 내용은 필수입니다."),
+  CHAPTER_DURATION_REQUIRED("챕터 영상 정보는 필수입니다."),
 
-	// 가격
-	PRICE_REQUIRED("가격은 필수입니다."),
-	PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
+  // 가격
+  PRICE_REQUIRED("가격은 필수입니다."),
+  PRICE_NEGATIVE("가격은 0원 이상이어야 합니다."),
 
-	// 강사
-	INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
-	INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
-	INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
+  // 강사
+  INSTRUCTOR_ID_REQUIRED("강사 ID는 필수입니다."),
+  INSTRUCTOR_NAME_REQUIRED("강사 이름은 필수입니다."),
+  INSTRUCTOR_NAME_TOO_LONG("강사 이름은 100자 이하여야 합니다.");
 
-	private final String message;
+  private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/LectureController.java
@@ -4,6 +4,10 @@ import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.LectureService;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdateResult;
@@ -12,6 +16,11 @@ import com.goggles.lecture_service.application.lecture.query.dto.LectureListQuer
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateRequest;
 import com.goggles.lecture_service.presentation.lecture.dto.ChapterCreateResponse;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterDeleteResponse;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterReorderRequest;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterReorderResponse;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterUpdateRequest;
+import com.goggles.lecture_service.presentation.lecture.dto.ChapterUpdateResponse;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateRequest;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureCreateResponse;
 import com.goggles.lecture_service.presentation.lecture.dto.LectureDeleteResponse;
@@ -103,5 +112,49 @@ public class LectureController {
       @Valid @RequestBody ChapterCreateRequest request) {
     ChapterCreateResult result = lectureService.createChapter(request.toCommand(lectureId));
     return ChapterCreateResponse.from(result);
+  }
+
+  // 챕터 수정 (DRAFT 상태에서만)
+  @PatchMapping("/{lectureId}/chapters/{chapterId}")
+  public ChapterUpdateResponse updateChapter(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @PathVariable UUID lectureId,
+      @PathVariable UUID chapterId,
+      @Valid @RequestBody ChapterUpdateRequest request) {
+
+    ChapterUpdateResult result =
+        lectureService.updateChapter(request.toCommand(lectureId, chapterId, userId, userRole));
+
+    return ChapterUpdateResponse.from(result);
+  }
+
+  // 챕터 삭제 (DRAFT 상태에서만)
+  @DeleteMapping("/{lectureId}/chapters/{chapterId}")
+  public ChapterDeleteResponse deleteChapter(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @PathVariable UUID lectureId,
+      @PathVariable UUID chapterId) {
+
+    ChapterDeleteResult result =
+        lectureService.deleteChapter(
+            new ChapterDeleteCommand(lectureId, chapterId, userId, userRole));
+
+    return ChapterDeleteResponse.from(result);
+  }
+
+  // 챕터 일괄 순서 변경 (DRAFT 상태에서만)
+  @PatchMapping("/{lectureId}/chapters/reorder")
+  public ChapterReorderResponse reorderChapters(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @PathVariable UUID lectureId,
+      @Valid @RequestBody ChapterReorderRequest request) {
+
+    ChapterReorderResult result =
+        lectureService.reorderChapters(request.toCommand(lectureId, userId, userRole));
+
+    return ChapterReorderResponse.from(result);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterDeleteResponse.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteResult;
+import java.util.UUID;
+
+public record ChapterDeleteResponse(UUID lectureId, UUID chapterId) {
+  public static ChapterDeleteResponse from(ChapterDeleteResult result) {
+    return new ChapterDeleteResponse(result.lectureId(), result.chapterId());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterReorderRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterReorderRequest.java
@@ -1,0 +1,32 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+public record ChapterReorderRequest(
+    @NotEmpty(message = "챕터 순서 변경 목록은 비어 있을 수 없습니다.")
+        List<@Valid @NotNull ChapterOrderRequest> orders) {
+
+  public ChapterReorderCommand toCommand(UUID lectureId, UUID actorId, String actorRole) {
+    return new ChapterReorderCommand(
+        lectureId,
+        actorId,
+        actorRole,
+        orders.stream()
+            .map(
+                order ->
+                    new ChapterReorderCommand.ChapterOrderCommand(
+                        order.chapterId(), order.sortOrder()))
+            .toList());
+  }
+
+  public record ChapterOrderRequest(
+      @NotNull(message = "챕터 ID는 필수입니다.") UUID chapterId,
+      @NotNull(message = "챕터 순서는 필수입니다.") @Min(value = 1, message = "챕터 순서는 1 이상이어야 합니다.")
+          Integer sortOrder) {}
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterReorderRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterReorderRequest.java
@@ -13,16 +13,19 @@ public record ChapterReorderRequest(
         List<@Valid @NotNull ChapterOrderRequest> orders) {
 
   public ChapterReorderCommand toCommand(UUID lectureId, UUID actorId, String actorRole) {
-    return new ChapterReorderCommand(
-        lectureId,
-        actorId,
-        actorRole,
-        orders.stream()
-            .map(
-                order ->
-                    new ChapterReorderCommand.ChapterOrderCommand(
-                        order.chapterId(), order.sortOrder()))
-            .toList());
+    List<ChapterReorderCommand.ChapterOrderCommand> mappedOrders =
+        orders == null
+            ? null
+            : orders.stream()
+                .map(
+                    order ->
+                        order == null
+                            ? null
+                            : new ChapterReorderCommand.ChapterOrderCommand(
+                                order.chapterId(), order.sortOrder()))
+                .toList();
+
+    return new ChapterReorderCommand(lectureId, actorId, actorRole, mappedOrders);
   }
 
   public record ChapterOrderRequest(

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterReorderResponse.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterReorderResponse.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderResult;
+import java.util.UUID;
+
+public record ChapterReorderResponse(UUID lectureId) {
+  public static ChapterReorderResponse from(ChapterReorderResult result) {
+    return new ChapterReorderResponse(result.lectureId());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterUpdateRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ChapterUpdateRequest(
+    @NotBlank(message = "챕터 제목은 필수입니다.") String title,
+    @NotBlank(message = "챕터 내용은 필수입니다.") String content,
+    @NotNull(message = "영상 길이는 필수입니다.") @Min(value = 1, message = "영상 길이는 1 이상이어야 합니다.")
+        Integer durationSeconds) {
+
+  public ChapterUpdateCommand toCommand(
+      UUID lectureId, UUID chapterId, UUID actorId, String actorRole) {
+    return new ChapterUpdateCommand(
+        lectureId, chapterId, actorId, actorRole, title, content, durationSeconds);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterUpdateResponse.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/ChapterUpdateResponse.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateResult;
+import java.util.UUID;
+
+public record ChapterUpdateResponse(UUID lectureId, UUID chapterId) {
+  public static ChapterUpdateResponse from(ChapterUpdateResult result) {
+    return new ChapterUpdateResponse(result.lectureId(), result.chapterId());
+  }
+}

--- a/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/LectureCommandServiceImplTest.java
@@ -6,6 +6,12 @@ import static org.mockito.Mockito.*;
 
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.ChapterCreateResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterDeleteResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterReorderResult;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateCommand;
+import com.goggles.lecture_service.application.lecture.command.dto.ChapterUpdateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateCommand;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureCreateResult;
 import com.goggles.lecture_service.application.lecture.command.dto.LectureDeleteCommand;
@@ -16,6 +22,7 @@ import com.goggles.lecture_service.application.lecture.command.service.LectureCo
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
+import com.goggles.lecture_service.domain.lecture.exception.ChapterNotFoundException;
 import com.goggles.lecture_service.domain.lecture.exception.DuplicateSortOrderException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidCategoryException;
 import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureFieldException;
@@ -23,6 +30,7 @@ import com.goggles.lecture_service.domain.lecture.exception.InvalidLectureStatus
 import com.goggles.lecture_service.domain.lecture.exception.LectureAccessDeniedException;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -478,6 +486,449 @@ class LectureCommandServiceImplTest {
     }
   }
 
+  @Nested
+  @DisplayName("챕터 수정")
+  class UpdateChapter {
+
+    @Test
+    @DisplayName("성공: 강의 소유자가 DRAFT 상태 강의의 챕터를 수정한다")
+    void updateChapter_byOwner_success() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 1);
+      UUID chapterId = lecture.getChapterViews().get(0).id();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      ChapterUpdateResult result =
+          lectureCommandService.updateChapter(
+              new ChapterUpdateCommand(
+                  lecture.getId(), chapterId, instructorId, "INSTRUCTOR", "수정된 챕터", "수정된 내용", 900));
+
+      assertThat(result.lectureId()).isEqualTo(lecture.getId());
+      assertThat(result.chapterId()).isEqualTo(chapterId);
+      assertThat(lecture.getChapterViews().get(0).title()).isEqualTo("수정된 챕터");
+      assertThat(lecture.getChapterViews().get(0).content()).isEqualTo("수정된 내용");
+      assertThat(lecture.getChapterViews().get(0).durationSeconds()).isEqualTo(900);
+    }
+
+    @Test
+    @DisplayName("성공: 관리자(MASTER)가 DRAFT 상태 강의의 챕터를 수정한다")
+    void updateChapter_byMaster_success() {
+      Lecture lecture = draftLectureWithChapters(UUID.randomUUID(), 1);
+      UUID chapterId = lecture.getChapterViews().get(0).id();
+      UUID master = UUID.randomUUID();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      ChapterUpdateResult result =
+          lectureCommandService.updateChapter(
+              new ChapterUpdateCommand(
+                  lecture.getId(), chapterId, master, "MASTER", "수정된 챕터", "수정된 내용", 900));
+
+      assertThat(result.lectureId()).isEqualTo(lecture.getId());
+      assertThat(result.chapterId()).isEqualTo(chapterId);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 강의의 챕터 수정")
+    void updateChapter_lectureNotFound_throws() {
+      UUID lectureId = UUID.randomUUID();
+      UUID chapterId = UUID.randomUUID();
+
+      when(lectureRepository.findById(lectureId)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.updateChapter(
+                      new ChapterUpdateCommand(
+                          lectureId, chapterId, UUID.randomUUID(), "INSTRUCTOR", "제목", "내용", 600)))
+          .isInstanceOf(LectureNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 챕터 수정")
+    void updateChapter_chapterNotFound_throws() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 1);
+      UUID notFoundChapterId = UUID.randomUUID();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.updateChapter(
+                      new ChapterUpdateCommand(
+                          lecture.getId(),
+                          notFoundChapterId,
+                          instructorId,
+                          "INSTRUCTOR",
+                          "제목",
+                          "내용",
+                          600)))
+          .isInstanceOf(ChapterNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("실패: DRAFT가 아닌 강의의 챕터 수정")
+    void updateChapter_notDraft_throws() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = publishedLecture(instructorId);
+      UUID chapterId = lecture.getChapterViews().get(0).id();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.updateChapter(
+                      new ChapterUpdateCommand(
+                          lecture.getId(), chapterId, instructorId, "INSTRUCTOR", "제목", "내용", 600)))
+          .isInstanceOf(InvalidLectureStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 소유자가 아닌 사용자가 챕터 수정")
+    void updateChapter_notOwner_throws() {
+      Lecture lecture = draftLectureWithChapters(UUID.randomUUID(), 1);
+      UUID chapterId = lecture.getChapterViews().get(0).id();
+      UUID otherUser = UUID.randomUUID();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.updateChapter(
+                      new ChapterUpdateCommand(
+                          lecture.getId(), chapterId, otherUser, "INSTRUCTOR", "제목", "내용", 600)))
+          .isInstanceOf(LectureAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("실패: Command 검증 - lectureId null")
+    void updateChapter_nullLectureId_throws() {
+      assertThatThrownBy(
+              () ->
+                  new ChapterUpdateCommand(
+                      null, UUID.randomUUID(), UUID.randomUUID(), "INSTRUCTOR", "제목", "내용", 600))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: Command 검증 - chapterId null")
+    void updateChapter_nullChapterId_throws() {
+      assertThatThrownBy(
+              () ->
+                  new ChapterUpdateCommand(
+                      UUID.randomUUID(), null, UUID.randomUUID(), "INSTRUCTOR", "제목", "내용", 600))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: Command 검증 - actorId null")
+    void updateChapter_nullActorId_throws() {
+      assertThatThrownBy(
+              () ->
+                  new ChapterUpdateCommand(
+                      UUID.randomUUID(), UUID.randomUUID(), null, "INSTRUCTOR", "제목", "내용", 600))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: Command 검증 - actorRole blank")
+    void updateChapter_blankActorRole_throws() {
+      assertThatThrownBy(
+              () ->
+                  new ChapterUpdateCommand(
+                      UUID.randomUUID(),
+                      UUID.randomUUID(),
+                      UUID.randomUUID(),
+                      "  ",
+                      "제목",
+                      "내용",
+                      600))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("챕터 삭제")
+  class DeleteChapter {
+
+    @Test
+    @DisplayName("성공: 강의 소유자가 DRAFT 상태 강의의 챕터를 삭제한다")
+    void deleteChapter_byOwner_success() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 2);
+      UUID chapterId = lecture.getChapterViews().get(0).id();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      ChapterDeleteResult result =
+          lectureCommandService.deleteChapter(
+              new ChapterDeleteCommand(lecture.getId(), chapterId, instructorId, "INSTRUCTOR"));
+
+      assertThat(result.lectureId()).isEqualTo(lecture.getId());
+      assertThat(result.chapterId()).isEqualTo(chapterId);
+      assertThat(lecture.getChapterCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("성공: 관리자(MASTER)가 DRAFT 상태 강의의 챕터를 삭제한다")
+    void deleteChapter_byMaster_success() {
+      Lecture lecture = draftLectureWithChapters(UUID.randomUUID(), 2);
+      UUID chapterId = lecture.getChapterViews().get(0).id();
+      UUID master = UUID.randomUUID();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      ChapterDeleteResult result =
+          lectureCommandService.deleteChapter(
+              new ChapterDeleteCommand(lecture.getId(), chapterId, master, "MASTER"));
+
+      assertThat(result.lectureId()).isEqualTo(lecture.getId());
+      assertThat(result.chapterId()).isEqualTo(chapterId);
+      assertThat(lecture.getChapterCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 강의의 챕터 삭제")
+    void deleteChapter_lectureNotFound_throws() {
+      UUID lectureId = UUID.randomUUID();
+
+      when(lectureRepository.findById(lectureId)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.deleteChapter(
+                      new ChapterDeleteCommand(
+                          lectureId, UUID.randomUUID(), UUID.randomUUID(), "INSTRUCTOR")))
+          .isInstanceOf(LectureNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 챕터 삭제")
+    void deleteChapter_chapterNotFound_throws() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 1);
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.deleteChapter(
+                      new ChapterDeleteCommand(
+                          lecture.getId(), UUID.randomUUID(), instructorId, "INSTRUCTOR")))
+          .isInstanceOf(ChapterNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("실패: DRAFT가 아닌 강의의 챕터 삭제")
+    void deleteChapter_notDraft_throws() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = publishedLecture(instructorId);
+      UUID chapterId = lecture.getChapterViews().get(0).id();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.deleteChapter(
+                      new ChapterDeleteCommand(
+                          lecture.getId(), chapterId, instructorId, "INSTRUCTOR")))
+          .isInstanceOf(InvalidLectureStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 소유자가 아닌 사용자가 챕터 삭제")
+    void deleteChapter_notOwner_throws() {
+      Lecture lecture = draftLectureWithChapters(UUID.randomUUID(), 1);
+      UUID chapterId = lecture.getChapterViews().get(0).id();
+      UUID otherUser = UUID.randomUUID();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.deleteChapter(
+                      new ChapterDeleteCommand(
+                          lecture.getId(), chapterId, otherUser, "INSTRUCTOR")))
+          .isInstanceOf(LectureAccessDeniedException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("챕터 순서 변경")
+  class ReorderChapters {
+
+    @Test
+    @DisplayName("성공: 여러 챕터 순서를 일괄 변경한다")
+    void reorderChapters_success() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 3);
+
+      UUID firstChapterId = lecture.getChapterViews().get(0).id();
+      UUID secondChapterId = lecture.getChapterViews().get(1).id();
+      UUID thirdChapterId = lecture.getChapterViews().get(2).id();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      ChapterReorderResult result =
+          lectureCommandService.reorderChapters(
+              new ChapterReorderCommand(
+                  lecture.getId(),
+                  instructorId,
+                  "INSTRUCTOR",
+                  List.of(
+                      new ChapterReorderCommand.ChapterOrderCommand(firstChapterId, 3),
+                      new ChapterReorderCommand.ChapterOrderCommand(secondChapterId, 1),
+                      new ChapterReorderCommand.ChapterOrderCommand(thirdChapterId, 2))));
+
+      assertThat(result.lectureId()).isEqualTo(lecture.getId());
+      assertThat(lecture.getChapterViews())
+          .extracting("sortOrder")
+          .containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("성공: swap 케이스도 처리한다")
+    void reorderChapters_swap_success() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 2);
+
+      UUID firstChapterId = lecture.getChapterViews().get(0).id();
+      UUID secondChapterId = lecture.getChapterViews().get(1).id();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      lectureCommandService.reorderChapters(
+          new ChapterReorderCommand(
+              lecture.getId(),
+              instructorId,
+              "INSTRUCTOR",
+              List.of(
+                  new ChapterReorderCommand.ChapterOrderCommand(firstChapterId, 2),
+                  new ChapterReorderCommand.ChapterOrderCommand(secondChapterId, 1))));
+
+      assertThat(lecture.getChapterViews())
+          .filteredOn(view -> view.id().equals(firstChapterId))
+          .singleElement()
+          .extracting("sortOrder")
+          .isEqualTo(2);
+
+      assertThat(lecture.getChapterViews())
+          .filteredOn(view -> view.id().equals(secondChapterId))
+          .singleElement()
+          .extracting("sortOrder")
+          .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("성공: 일부 챕터만 순서를 변경한다")
+    void reorderChapters_partial_success() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 2);
+
+      UUID firstChapterId = lecture.getChapterViews().get(0).id();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      lectureCommandService.reorderChapters(
+          new ChapterReorderCommand(
+              lecture.getId(),
+              instructorId,
+              "INSTRUCTOR",
+              List.of(new ChapterReorderCommand.ChapterOrderCommand(firstChapterId, 3))));
+
+      assertThat(lecture.getChapterViews())
+          .filteredOn(view -> view.id().equals(firstChapterId))
+          .singleElement()
+          .extracting("sortOrder")
+          .isEqualTo(3);
+
+      assertThat(lecture.getChapterViews())
+          .filteredOn(view -> !view.id().equals(firstChapterId))
+          .singleElement()
+          .extracting("sortOrder")
+          .isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 챕터 ID가 포함되면 예외 발생")
+    void reorderChapters_chapterNotFound_throws() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 2);
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.reorderChapters(
+                      new ChapterReorderCommand(
+                          lecture.getId(),
+                          instructorId,
+                          "INSTRUCTOR",
+                          List.of(
+                              new ChapterReorderCommand.ChapterOrderCommand(
+                                  UUID.randomUUID(), 3)))))
+          .isInstanceOf(ChapterNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 변경 후 sortOrder가 중복되면 예외 발생")
+    void reorderChapters_duplicateSortOrder_throws() {
+      UUID instructorId = UUID.randomUUID();
+      Lecture lecture = draftLectureWithChapters(instructorId, 3);
+
+      UUID firstChapterId = lecture.getChapterViews().get(0).id();
+
+      when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
+
+      assertThatThrownBy(
+              () ->
+                  lectureCommandService.reorderChapters(
+                      new ChapterReorderCommand(
+                          lecture.getId(),
+                          instructorId,
+                          "INSTRUCTOR",
+                          List.of(
+                              new ChapterReorderCommand.ChapterOrderCommand(firstChapterId, 2)))))
+          .isInstanceOf(DuplicateSortOrderException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 빈 orders이면 Command 예외 발생")
+    void reorderChapters_emptyOrders_throws() {
+      assertThatThrownBy(
+              () ->
+                  new ChapterReorderCommand(
+                      UUID.randomUUID(), UUID.randomUUID(), "INSTRUCTOR", List.of()))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 중복 chapterId가 있으면 Command 예외 발생")
+    void reorderChapters_duplicatedChapterId_throws() {
+      UUID chapterId = UUID.randomUUID();
+
+      assertThatThrownBy(
+              () ->
+                  new ChapterReorderCommand(
+                      UUID.randomUUID(),
+                      UUID.randomUUID(),
+                      "INSTRUCTOR",
+                      List.of(
+                          new ChapterReorderCommand.ChapterOrderCommand(chapterId, 1),
+                          new ChapterReorderCommand.ChapterOrderCommand(chapterId, 2))))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: sortOrder가 1보다 작으면 Command 예외 발생")
+    void reorderChapters_invalidSortOrder_throws() {
+      assertThatThrownBy(() -> new ChapterReorderCommand.ChapterOrderCommand(UUID.randomUUID(), 0))
+          .isInstanceOf(InvalidLectureFieldException.class);
+    }
+  }
+
   // 헬퍼
   private Lecture draftLecture(UUID instructorId) {
     return Lecture.create(
@@ -490,5 +941,17 @@ class LectureCommandServiceImplTest {
     l.submitForReview();
     l.approve();
     return l;
+  }
+
+  private Lecture draftLectureWithChapters(UUID instructorId, int chapterCount) {
+    Lecture lecture =
+        Lecture.create(
+            instructorId, "강사명", "BACKEND", "스프링 강의", "부제", "설명", DurationPolicy.DAYS_365, 10000L);
+
+    for (int i = 1; i <= chapterCount; i++) {
+      lecture.addChapter("챕터" + i, "내용" + i, i, 600);
+    }
+
+    return lecture;
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈

close #20 

### 💡 작업 내용

* 챕터 수정 API 구현
  * PATCH /api/v1/lectures/{lectureId}/chapters/{chapterId}
* 챕터 삭제 API 구현
  * DELETE /api/v1/lectures/{lectureId}/chapters/{chapterId}
* 챕터 순서 변경 API 구현
  * PATCH /api/v1/lectures/{lectureId}/chapters/reorder
* 챕터 수정/삭제/순서 변경 Command, Result, Request, Response DTO 추가
* 단건 reorder 방식 대신 Map 기반 일괄 순서 변경 방식으로 변경
* Lecture.getChapters() 직접 노출을 제거하고 ChapterView 기반 조회 구조로 변경(이전 PR 리뷰 적용)
* 챕터 수정/삭제/순서 변경 성공 및 실패 케이스 단위 테스트 추가

### 🔍 변경 이유

* 챕터는 Lecture 애그리거트 내부 엔티티이므로 외부에서 직접 수정하지 않고, Lecture 애그리거트 루트를 통해서만 수정/삭제/순서 변경이 이루어지도록 했습니다.
* 챕터 수정/삭제/순서 변경은 강의 소유자인 강사 또는 관리자만 수행할 수 있어야 하므로 기존 강의 권한 검증 로직을 재사용했습니다.
* 챕터 변경은 강의가 DRAFT 상태일 때만 가능하도록 도메인 메서드 내부에서 상태 검증을 수행했습니다.
* 챕터 순서 변경은 swap 케이스처럼 여러 챕터의 순서가 동시에 바뀔 수 있어, 단건 변경 방식이 아닌 일괄 변경 방식으로 처리했습니다.
* getChapters()로 Chapter 엔티티를 직접 노출하면 애그리거트 내부 엔티티가 외부에 드러날 수 있어, 조회 전용 ChapterView를 반환하도록 개선했습니다.

### 📝 리뷰 포인트

* 챕터 수정/삭제/순서 변경을 Lecture 애그리거트 루트에서 처리한 방식이 적절한지
* 챕터 순서 변경을 단건이 아닌 일괄 처리 방식으로 구현한 구조가 적절한지
* 변경 후 최종 sortOrder 기준으로 중복을 검증하는 방식이 적절한지
* Chapter 엔티티 직접 노출 대신 ChapterView를 반환하도록 변경한 방식이 적절한지
* 강의 수정/삭제 PR에서 추가한 권한 검증 로직을 챕터 기능에서도 재사용한 방식이 적절한지

### 🧠 기타 참고 사항

* 현재 인증/인가 연동이 완성되지 않아 X-User-Id, X-User-Role 헤더를 통해 사용자 정보를 임시로 전달받고 있습니다 추후 user-service 및 인증 시스템 연동 후 반영 예정입니다
* 챕터 수정/삭제/순서 변경은 DRAFT 상태의 강의에서만 가능합니다.
* 챕터 순서 변경처럼 여러 챕터에 영향을 주는 기능은 일괄 처리 방식으로 구현했습니다.
* 추후 고도화 시 챕터 일괄 생성이 필요해지면 Lecture 애그리거트 루트를 통해 처리하는 방향으로 검토하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 강의 챕터 편집 기능 추가 (제목, 내용, 재생 시간 수정 가능)
  * 강의 챕터 삭제 기능 추가
  * 강의 챕터 일괄 재정렬 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->