### PR TITLE
[FEAT] 나의 강의 조회 API 구현

### DIFF
--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/dto/EnrolledLectureQuery.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/dto/EnrolledLectureQuery.java
@@ -1,0 +1,54 @@
+package com.goggles.lecture_service.application.enrollment.query.dto;
+
+import static com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode.*;
+
+import com.goggles.common.pagination.CommonPageRequest;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrolledLectureSort;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentStatusException;
+import java.util.UUID;
+
+public record EnrolledLectureQuery(
+    UUID studentId,
+    String keyword,
+    EnrollmentStatus status,
+    EnrolledLectureSort sort,
+    CommonPageRequest pageRequest) {
+
+  public EnrolledLectureQuery {
+    if (studentId == null) {
+      throw new InvalidEnrollmentFieldException(ENROLLMENT_USER_ID_REQUIRED);
+    }
+
+    if (pageRequest == null) {
+      throw new InvalidEnrollmentFieldException(ENROLLMENT_PAGE_REQUEST_REQUIRED);
+    }
+  }
+
+  public static EnrolledLectureQuery of(
+      UUID studentId, String keyword, String status, String sort, CommonPageRequest pageRequest) {
+    return new EnrolledLectureQuery(
+        studentId, keyword, parseStatus(status), EnrolledLectureSort.from(sort), pageRequest);
+  }
+
+  private static EnrollmentStatus parseStatus(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+
+    try {
+      EnrollmentStatus status = EnrollmentStatus.valueOf(value.toUpperCase());
+      validateSearchableStatus(status);
+      return status;
+    } catch (IllegalArgumentException e) {
+      throw new InvalidEnrollmentFieldException(ENROLLMENT_STATUS_INVALID);
+    }
+  }
+
+  private static void validateSearchableStatus(EnrollmentStatus status) {
+    if (status == EnrollmentStatus.RESERVE || status == EnrollmentStatus.CANCELED) {
+      throw new InvalidEnrollmentStatusException(ENROLLMENT_STATUS_NOT_SEARCHABLE);
+    }
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/dto/EnrolledLectureResult.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/dto/EnrolledLectureResult.java
@@ -1,0 +1,34 @@
+package com.goggles.lecture_service.application.enrollment.query.dto;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record EnrolledLectureResult(
+    UUID enrollmentId,
+    UUID lectureId,
+    String lectureTitle,
+    UUID instructorId,
+    String instructorName,
+    EnrollmentStatus status,
+    DurationPolicy durationPolicy,
+    LocalDateTime activatedAt,
+    LocalDateTime expiresAt,
+    LocalDateTime lastAccessedAt) {
+
+  public static EnrolledLectureResult from(Enrollment enrollment) {
+    return new EnrolledLectureResult(
+        enrollment.getId(),
+        enrollment.getLectureSnapshot().getLectureId(),
+        enrollment.getLectureSnapshot().getLectureTitle(),
+        enrollment.getLectureSnapshot().getInstructorId(),
+        enrollment.getLectureSnapshot().getInstructorName(),
+        enrollment.getStatus(),
+        enrollment.getDurationPolicy(),
+        enrollment.getActivatedAt(),
+        enrollment.getExpiresAt(),
+        enrollment.getLastAccessedAt());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/dto/EnrolledLectureSummary.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/dto/EnrolledLectureSummary.java
@@ -1,0 +1,34 @@
+package com.goggles.lecture_service.application.enrollment.query.dto;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record EnrolledLectureSummary(
+    UUID enrollmentId,
+    UUID lectureId,
+    String lectureTitle,
+    UUID instructorId,
+    String instructorName,
+    EnrollmentStatus status,
+    DurationPolicy durationPolicy,
+    LocalDateTime activatedAt,
+    LocalDateTime expiresAt,
+    LocalDateTime lastAccessedAt) {
+
+  public static EnrolledLectureSummary from(Enrollment enrollment) {
+    return new EnrolledLectureSummary(
+        enrollment.getId(),
+        enrollment.getLectureSnapshot().getLectureId(),
+        enrollment.getLectureSnapshot().getLectureTitle(),
+        enrollment.getLectureSnapshot().getInstructorId(),
+        enrollment.getLectureSnapshot().getInstructorName(),
+        enrollment.getStatus(),
+        enrollment.getDurationPolicy(),
+        enrollment.getActivatedAt(),
+        enrollment.getExpiresAt(),
+        enrollment.getLastAccessedAt());
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryService.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryService.java
@@ -1,0 +1,10 @@
+package com.goggles.lecture_service.application.enrollment.query.service;
+
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureSummary;
+import java.util.List;
+import java.util.UUID;
+
+public interface EnrollmentQueryService {
+
+  List<EnrolledLectureSummary> getEnrolledLectures(UUID studentId);
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryService.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryService.java
@@ -1,10 +1,10 @@
 package com.goggles.lecture_service.application.enrollment.query.service;
 
-import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureSummary;
-import java.util.List;
-import java.util.UUID;
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureQuery;
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureResult;
+import org.springframework.data.domain.Page;
 
 public interface EnrollmentQueryService {
 
-  List<EnrolledLectureSummary> getEnrolledLectures(UUID studentId);
+  Page<EnrolledLectureResult> getEnrolledLectures(EnrolledLectureQuery query);
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryService.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryService.java
@@ -1,10 +1,10 @@
 package com.goggles.lecture_service.application.enrollment.query.service;
 
+import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureQuery;
 import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureResult;
-import org.springframework.data.domain.Page;
 
 public interface EnrollmentQueryService {
 
-  Page<EnrolledLectureResult> getEnrolledLectures(EnrolledLectureQuery query);
+  CommonPageResponse<EnrolledLectureResult> getEnrolledLectures(EnrolledLectureQuery query);
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.goggles.lecture_service.application.enrollment.query.service;
+
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureSummary;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EnrollmentQueryServiceImpl implements EnrollmentQueryService {
+
+  private final EnrollmentRepository enrollmentRepository;
+
+  @Override
+  public List<EnrolledLectureSummary> getEnrolledLectures(UUID studentId) {
+    return enrollmentRepository.findActiveByStudentId(studentId).stream()
+        .map(EnrolledLectureSummary::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryServiceImpl.java
@@ -1,12 +1,11 @@
 package com.goggles.lecture_service.application.enrollment.query.service;
 
+import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureQuery;
 import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureResult;
-import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrolledLecturePageQuery;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +17,7 @@ public class EnrollmentQueryServiceImpl implements EnrollmentQueryService {
   private final EnrollmentRepository enrollmentRepository;
 
   @Override
-  public Page<EnrolledLectureResult> getEnrolledLectures(EnrolledLectureQuery query) {
+  public CommonPageResponse<EnrolledLectureResult> getEnrolledLectures(EnrolledLectureQuery query) {
     EnrolledLecturePageQuery pageQuery =
         new EnrolledLecturePageQuery(
             query.studentId(),
@@ -28,8 +27,6 @@ public class EnrollmentQueryServiceImpl implements EnrollmentQueryService {
             query.pageRequest().getPage(),
             query.pageRequest().getSize());
 
-    Page<Enrollment> enrollments = enrollmentRepository.findEnrolledLectures(pageQuery);
-
-    return enrollments.map(EnrolledLectureResult::from);
+    return enrollmentRepository.findEnrolledLectures(pageQuery, EnrolledLectureResult::from);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/query/service/EnrollmentQueryServiceImpl.java
@@ -1,10 +1,12 @@
 package com.goggles.lecture_service.application.enrollment.query.service;
 
-import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureSummary;
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureQuery;
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureResult;
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrolledLecturePageQuery;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,9 +18,18 @@ public class EnrollmentQueryServiceImpl implements EnrollmentQueryService {
   private final EnrollmentRepository enrollmentRepository;
 
   @Override
-  public List<EnrolledLectureSummary> getEnrolledLectures(UUID studentId) {
-    return enrollmentRepository.findActiveByStudentId(studentId).stream()
-        .map(EnrolledLectureSummary::from)
-        .toList();
+  public Page<EnrolledLectureResult> getEnrolledLectures(EnrolledLectureQuery query) {
+    EnrolledLecturePageQuery pageQuery =
+        new EnrolledLecturePageQuery(
+            query.studentId(),
+            query.keyword(),
+            query.status(),
+            query.sort(),
+            query.pageRequest().getPage(),
+            query.pageRequest().getSize());
+
+    Page<Enrollment> enrollments = enrollmentRepository.findEnrolledLectures(pageQuery);
+
+    return enrollments.map(EnrolledLectureResult::from);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
@@ -22,6 +22,7 @@ import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdate
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
+import java.util.List;
 import java.util.UUID;
 
 public interface LectureService {
@@ -42,6 +43,8 @@ public interface LectureService {
   LectureStatusChangeResult submitReview(LectureSubmitReviewCommand command);
 
   LectureStatusChangeResult changeStatus(LectureStatusChangeCommand command);
+
+  List<LectureSummary> getTeachingLectures(UUID instructorId);
 
   ChapterUpdateResult updateChapter(ChapterUpdateCommand command);
 

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
@@ -23,7 +23,6 @@ import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
 
 public interface LectureService {
 
@@ -44,7 +43,8 @@ public interface LectureService {
 
   LectureStatusChangeResult changeStatus(LectureStatusChangeCommand command);
 
-  Page<LectureSummary> getTeachingLectures(UUID instructorId, CommonPageRequest pageRequest);
+  CommonPageResponse<LectureSummary> getTeachingLectures(
+      UUID instructorId, CommonPageRequest pageRequest);
 
   ChapterUpdateResult updateChapter(ChapterUpdateCommand command);
 

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureService.java
@@ -22,8 +22,8 @@ import com.goggles.lecture_service.application.lecture.command.dto.LectureUpdate
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
-import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface LectureService {
 
@@ -44,7 +44,7 @@ public interface LectureService {
 
   LectureStatusChangeResult changeStatus(LectureStatusChangeCommand command);
 
-  List<LectureSummary> getTeachingLectures(UUID instructorId);
+  Page<LectureSummary> getTeachingLectures(UUID instructorId, CommonPageRequest pageRequest);
 
   ChapterUpdateResult updateChapter(ChapterUpdateCommand command);
 

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
@@ -24,9 +24,9 @@ import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.application.lecture.query.service.LectureQueryService;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -78,8 +78,9 @@ public class LectureServiceImpl implements LectureService {
   }
 
   @Override
-  public List<LectureSummary> getTeachingLectures(UUID instructorId) {
-    return lectureQueryService.getTeachingLectures(instructorId);
+  public Page<LectureSummary> getTeachingLectures(
+      UUID instructorId, CommonPageRequest pageRequest) {
+    return lectureQueryService.getTeachingLectures(instructorId, pageRequest);
   }
 
   @Override

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
@@ -24,6 +24,7 @@ import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.application.lecture.query.service.LectureQueryService;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -74,6 +75,11 @@ public class LectureServiceImpl implements LectureService {
   @Override
   public LectureStatusChangeResult changeStatus(LectureStatusChangeCommand command) {
     return lectureCommandService.changeStatus(command);
+  }
+
+  @Override
+  public List<LectureSummary> getTeachingLectures(UUID instructorId) {
+    return lectureQueryService.getTeachingLectures(instructorId);
   }
 
   @Override

--- a/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/LectureServiceImpl.java
@@ -26,7 +26,6 @@ import com.goggles.lecture_service.application.lecture.query.service.LectureQuer
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -78,7 +77,7 @@ public class LectureServiceImpl implements LectureService {
   }
 
   @Override
-  public Page<LectureSummary> getTeachingLectures(
+  public CommonPageResponse<LectureSummary> getTeachingLectures(
       UUID instructorId, CommonPageRequest pageRequest) {
     return lectureQueryService.getTeachingLectures(instructorId, pageRequest);
   }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryService.java
@@ -6,7 +6,6 @@ import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
 
 public interface LectureQueryService {
 
@@ -15,5 +14,6 @@ public interface LectureQueryService {
 
   LectureDetail getLectureDetail(UUID lectureId);
 
-  Page<LectureSummary> getTeachingLectures(UUID instructorId, CommonPageRequest pageRequest);
+  CommonPageResponse<LectureSummary> getTeachingLectures(
+      UUID instructorId, CommonPageRequest pageRequest);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryService.java
@@ -5,6 +5,7 @@ import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
+import java.util.List;
 import java.util.UUID;
 
 public interface LectureQueryService {
@@ -13,4 +14,6 @@ public interface LectureQueryService {
       LectureSearchCondition condition, CommonPageRequest pageRequest);
 
   LectureDetail getLectureDetail(UUID lectureId);
+
+  List<LectureSummary> getTeachingLectures(UUID instructorId);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryService.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryService.java
@@ -5,8 +5,8 @@ import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
-import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface LectureQueryService {
 
@@ -15,5 +15,5 @@ public interface LectureQueryService {
 
   LectureDetail getLectureDetail(UUID lectureId);
 
-  List<LectureSummary> getTeachingLectures(UUID instructorId);
+  Page<LectureSummary> getTeachingLectures(UUID instructorId, CommonPageRequest pageRequest);
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryServiceImpl.java
@@ -10,9 +10,9 @@ import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureQueryRepository;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +31,10 @@ public class LectureQueryServiceImpl implements LectureQueryService {
   @Override
   public CommonPageResponse<LectureSummary> getLectures(
       LectureSearchCondition condition, CommonPageRequest pageRequest) {
-    return lectureQueryRepository.findAllByCondition(condition, pageRequest, LectureSummary::from);
+
+    Page<Lecture> page = lectureQueryRepository.findAllByCondition(condition, pageRequest);
+
+    return CommonPageResponse.of(page, LectureSummary::from);
   }
 
   @Override
@@ -45,9 +48,12 @@ public class LectureQueryServiceImpl implements LectureQueryService {
   }
 
   @Override
-  public List<LectureSummary> getTeachingLectures(UUID instructorId) {
-    return lectureRepository.findAllByInstructorId(instructorId).stream()
-        .map(LectureSummary::from)
-        .toList();
+  public Page<LectureSummary> getTeachingLectures(
+      UUID instructorId, CommonPageRequest pageRequest) {
+
+    Page<Lecture> lectures =
+        lectureQueryRepository.findAllByInstructorId(instructorId, pageRequest);
+
+    return lectures.map(LectureSummary::from);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryServiceImpl.java
@@ -12,7 +12,6 @@ import com.goggles.lecture_service.domain.lecture.repository.LectureQueryReposit
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,17 +23,10 @@ public class LectureQueryServiceImpl implements LectureQueryService {
   private final LectureRepository lectureRepository;
   private final LectureQueryRepository lectureQueryRepository;
 
-  /*
-   * TODO: common-library의 CommonPageResponse 에 map(Function) 메서드가 추가되면
-   */
-
   @Override
   public CommonPageResponse<LectureSummary> getLectures(
       LectureSearchCondition condition, CommonPageRequest pageRequest) {
-
-    Page<Lecture> page = lectureQueryRepository.findAllByCondition(condition, pageRequest);
-
-    return CommonPageResponse.of(page, LectureSummary::from);
+    return lectureQueryRepository.findAllByCondition(condition, pageRequest, LectureSummary::from);
   }
 
   @Override
@@ -48,12 +40,9 @@ public class LectureQueryServiceImpl implements LectureQueryService {
   }
 
   @Override
-  public Page<LectureSummary> getTeachingLectures(
+  public CommonPageResponse<LectureSummary> getTeachingLectures(
       UUID instructorId, CommonPageRequest pageRequest) {
-
-    Page<Lecture> lectures =
-        lectureQueryRepository.findAllByInstructorId(instructorId, pageRequest);
-
-    return lectures.map(LectureSummary::from);
+    return lectureQueryRepository.findAllByInstructorId(
+        instructorId, pageRequest, LectureSummary::from);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/lecture/query/service/LectureQueryServiceImpl.java
@@ -10,6 +10,7 @@ import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
 import com.goggles.lecture_service.domain.lecture.repository.LectureQueryRepository;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,5 +42,12 @@ public class LectureQueryServiceImpl implements LectureQueryService {
             .orElseThrow(() -> new LectureNotFoundException(lectureId));
 
     return LectureDetail.from(lecture);
+  }
+
+  @Override
+  public List<LectureSummary> getTeachingLectures(UUID instructorId) {
+    return lectureRepository.findAllByInstructorId(instructorId).stream()
+        .map(LectureSummary::from)
+        .toList();
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/enums/EnrolledLectureSort.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/enums/EnrolledLectureSort.java
@@ -1,0 +1,29 @@
+package com.goggles.lecture_service.domain.enrollment.enums;
+
+import static com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode.*;
+
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+import java.util.Arrays;
+
+public enum EnrolledLectureSort {
+  RECENT_ACCESSED("recentAccessed"),
+  EXPIRES_SOON("expiresSoon"),
+  RECENT_ACTIVATED("recentActivated");
+
+  private final String value;
+
+  EnrolledLectureSort(String value) {
+    this.value = value;
+  }
+
+  public static EnrolledLectureSort from(String value) {
+    if (value == null || value.isBlank()) {
+      return RECENT_ACCESSED;
+    }
+
+    return Arrays.stream(values())
+        .filter(type -> type.value.equalsIgnoreCase(value))
+        .findFirst()
+        .orElseThrow(() -> new InvalidEnrollmentFieldException(ENROLLMENT_SORT_INVALID));
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -46,7 +46,11 @@ public enum EnrollmentErrorCode {
   ENROLLMENT_PRODUCT_IDS_REQUIRED("상품 ID 목록은 필수입니다."),
   ENROLLMENT_PRODUCT_IDS_EMPTY("상품 ID 목록은 비어 있을 수 없습니다."),
   ENROLLMENT_USER_ID_REQUIRED("사용자 ID는 필수입니다."),
-  ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다.");
+  ENROLLMENT_USER_NAME_REQUIRED("사용자 이름은 필수입니다."),
+  ENROLLMENT_PAGE_REQUEST_REQUIRED("페이지 요청 정보는 필수입니다."),
+  ENROLLMENT_SORT_INVALID("유효하지 않은 수강 강의 정렬 조건입니다."),
+  ENROLLMENT_STATUS_INVALID("유효하지 않은 수강 상태입니다."),
+  ENROLLMENT_STATUS_NOT_SEARCHABLE("내 강의 목록에서는 조회할 수 없는 수강 상태입니다.");
 
   private final String message;
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrolledLecturePageQuery.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrolledLecturePageQuery.java
@@ -1,0 +1,13 @@
+package com.goggles.lecture_service.domain.enrollment.repository;
+
+import com.goggles.lecture_service.domain.enrollment.enums.EnrolledLectureSort;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import java.util.UUID;
+
+public record EnrolledLecturePageQuery(
+    UUID studentId,
+    String keyword,
+    EnrollmentStatus status,
+    EnrolledLectureSort sort,
+    int page,
+    int size) {}

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,10 +1,11 @@
 package com.goggles.lecture_service.domain.enrollment.repository;
 
+import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
+import java.util.function.Function;
 
 public interface EnrollmentRepository {
 
@@ -21,5 +22,6 @@ public interface EnrollmentRepository {
 
   List<Enrollment> findAllByOrderId(UUID orderId);
 
-  Page<Enrollment> findEnrolledLectures(EnrolledLecturePageQuery query);
+  <T> CommonPageResponse<T> findEnrolledLectures(
+      EnrolledLecturePageQuery query, Function<Enrollment, T> mapper);
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
@@ -4,6 +4,7 @@ import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface EnrollmentRepository {
 
@@ -20,6 +21,5 @@ public interface EnrollmentRepository {
 
   List<Enrollment> findAllByOrderId(UUID orderId);
 
-  // 학생의 ACTIVE 한 enrollment(내 강의 화면)
-  List<Enrollment> findActiveByStudentId(UUID studentId);
+  Page<Enrollment> findEnrolledLectures(EnrolledLecturePageQuery query);
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureQueryRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureQueryRepository.java
@@ -1,14 +1,17 @@
 package com.goggles.lecture_service.domain.lecture.repository;
 
 import com.goggles.common.pagination.CommonPageRequest;
+import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
+import java.util.function.Function;
 
 public interface LectureQueryRepository {
 
-  Page<Lecture> findAllByCondition(LectureSearchCondition condition, CommonPageRequest pageRequest);
+  <T> CommonPageResponse<T> findAllByCondition(
+      LectureSearchCondition condition, CommonPageRequest pageRequest, Function<Lecture, T> mapper);
 
-  Page<Lecture> findAllByInstructorId(UUID instructorId, CommonPageRequest pageRequest);
+  <T> CommonPageResponse<T> findAllByInstructorId(
+      UUID instructorId, CommonPageRequest pageRequest, Function<Lecture, T> mapper);
 }

--- a/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureQueryRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/lecture/repository/LectureQueryRepository.java
@@ -1,13 +1,14 @@
 package com.goggles.lecture_service.domain.lecture.repository;
 
 import com.goggles.common.pagination.CommonPageRequest;
-import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
-import java.util.function.Function;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface LectureQueryRepository {
 
-  <T> CommonPageResponse<T> findAllByCondition(
-      LectureSearchCondition condition, CommonPageRequest pageRequest, Function<Lecture, T> mapper);
+  Page<Lecture> findAllByCondition(LectureSearchCondition condition, CommonPageRequest pageRequest);
+
+  Page<Lecture> findAllByInstructorId(UUID instructorId, CommonPageRequest pageRequest);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
@@ -31,10 +31,5 @@ public interface EnrollmentJpaRepository extends JpaRepository<Enrollment, UUID>
 
   List<Enrollment> findAllByOrderId(UUID orderId);
 
-  @Query(
-      "select e from Enrollment e " + "where e.studentId = :studentId " + "and e.status = :status")
-  List<Enrollment> findByStudentIdAndStatus(
-      @Param("studentId") UUID studentId, @Param("status") EnrollmentStatus status);
-
   List<Enrollment> findAllByIdIn(List<UUID> ids);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentQueryDslRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentQueryDslRepository.java
@@ -2,6 +2,7 @@ package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
 import static com.goggles.lecture_service.domain.enrollment.QEnrollment.*;
 
+import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import com.goggles.lecture_service.domain.enrollment.enums.EnrolledLectureSort;
 import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
@@ -12,6 +13,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -28,7 +30,9 @@ public class EnrollmentQueryDslRepository {
 
   private final JPAQueryFactory queryFactory;
 
-  public Page<Enrollment> findEnrolledLectures(EnrolledLecturePageQuery query) {
+  public <T> CommonPageResponse<T> findEnrolledLectures(
+      EnrolledLecturePageQuery query, Function<Enrollment, T> mapper) {
+
     List<Enrollment> content =
         queryFactory
             .selectFrom(enrollment)
@@ -46,8 +50,8 @@ public class EnrollmentQueryDslRepository {
             .fetchOne();
 
     Pageable pageable = PageRequest.of(query.page(), query.size());
-
-    return new PageImpl<>(content, pageable, total != null ? total : 0);
+    Page<Enrollment> page = new PageImpl<>(content, pageable, total != null ? total : 0L);
+    return CommonPageResponse.of(page, mapper);
   }
 
   private BooleanExpression studentCondition(EnrolledLecturePageQuery query) {

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentQueryDslRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentQueryDslRepository.java
@@ -1,0 +1,97 @@
+package com.goggles.lecture_service.infrastructure.enrollment.repository;
+
+import static com.goggles.lecture_service.domain.enrollment.QEnrollment.*;
+
+import com.goggles.lecture_service.domain.enrollment.Enrollment;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrolledLectureSort;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrolledLecturePageQuery;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EnrollmentQueryDslRepository {
+
+  private static final Set<EnrollmentStatus> ENROLLED_HISTORY =
+      EnumSet.of(EnrollmentStatus.ACTIVE, EnrollmentStatus.EXPIRED);
+
+  private final JPAQueryFactory queryFactory;
+
+  public Page<Enrollment> findEnrolledLectures(EnrolledLecturePageQuery query) {
+    List<Enrollment> content =
+        queryFactory
+            .selectFrom(enrollment)
+            .where(studentCondition(query), statusCondition(query), keywordCondition(query))
+            .orderBy(orderSpecifiers(query.sort()))
+            .offset((long) query.page() * query.size())
+            .limit(query.size())
+            .fetch();
+
+    Long total =
+        queryFactory
+            .select(enrollment.count())
+            .from(enrollment)
+            .where(studentCondition(query), statusCondition(query), keywordCondition(query))
+            .fetchOne();
+
+    Pageable pageable = PageRequest.of(query.page(), query.size());
+
+    return new PageImpl<>(content, pageable, total != null ? total : 0);
+  }
+
+  private BooleanExpression studentCondition(EnrolledLecturePageQuery query) {
+    return enrollment.studentId.eq(query.studentId());
+  }
+
+  private BooleanExpression statusCondition(EnrolledLecturePageQuery query) {
+    if (query.status() != null) {
+      return enrollment.status.eq(query.status());
+    }
+
+    return enrollment.status.in(ENROLLED_HISTORY);
+  }
+
+  private BooleanExpression keywordCondition(EnrolledLecturePageQuery query) {
+    if (query.keyword() == null || query.keyword().isBlank()) {
+      return null;
+    }
+
+    String keyword = query.keyword().trim();
+
+    return enrollment
+        .lectureSnapshot
+        .lectureTitle
+        .containsIgnoreCase(keyword)
+        .or(enrollment.lectureSnapshot.instructorName.containsIgnoreCase(keyword));
+  }
+
+  private OrderSpecifier<?>[] orderSpecifiers(EnrolledLectureSort sort) {
+    EnrolledLectureSort resolved = sort == null ? EnrolledLectureSort.RECENT_ACCESSED : sort;
+
+    return switch (resolved) {
+      case RECENT_ACCESSED ->
+          new OrderSpecifier<?>[] {
+            enrollment.lastAccessedAt.desc().nullsLast(),
+            enrollment.activatedAt.desc().nullsLast(),
+            enrollment.id.desc()
+          };
+
+      case EXPIRES_SOON ->
+          new OrderSpecifier<?>[] {enrollment.expiresAt.asc().nullsLast(), enrollment.id.desc()};
+
+      case RECENT_ACTIVATED ->
+          new OrderSpecifier<?>[] {enrollment.activatedAt.desc().nullsLast(), enrollment.id.desc()};
+    };
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
+import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrolledLecturePageQuery;
@@ -9,8 +10,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -55,7 +56,8 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
   }
 
   @Override
-  public Page<Enrollment> findEnrolledLectures(EnrolledLecturePageQuery query) {
-    return queryDslRepository.findEnrolledLectures(query);
+  public <T> CommonPageResponse<T> findEnrolledLectures(
+      EnrolledLecturePageQuery query, Function<Enrollment, T> mapper) {
+    return queryDslRepository.findEnrolledLectures(query, mapper);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.goggles.lecture_service.infrastructure.enrollment.repository;
 
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrolledLecturePageQuery;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import java.util.EnumSet;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -19,6 +21,7 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
       EnumSet.of(EnrollmentStatus.RESERVE, EnrollmentStatus.ACTIVE);
 
   private final EnrollmentJpaRepository jpaRepository;
+  private final EnrollmentQueryDslRepository queryDslRepository;
 
   @Override
   public Enrollment save(Enrollment enrollment) {
@@ -52,7 +55,7 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
   }
 
   @Override
-  public List<Enrollment> findActiveByStudentId(UUID studentId) {
-    return jpaRepository.findByStudentIdAndStatus(studentId, EnrollmentStatus.ACTIVE);
+  public Page<Enrollment> findEnrolledLectures(EnrolledLecturePageQuery query) {
+    return queryDslRepository.findEnrolledLectures(query);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureQueryRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureQueryRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.goggles.lecture_service.infrastructure.lecture.repository;
 import static com.goggles.lecture_service.domain.lecture.QLecture.*;
 
 import com.goggles.common.pagination.CommonPageRequest;
-import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
@@ -12,7 +11,7 @@ import com.goggles.lecture_service.domain.lecture.repository.LectureQueryReposit
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import java.util.function.Function;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -28,14 +27,11 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public <T> CommonPageResponse<T> findAllByCondition(
-      LectureSearchCondition condition,
-      CommonPageRequest pageRequest,
-      Function<Lecture, T> mapper) {
+  public Page<Lecture> findAllByCondition(
+      LectureSearchCondition condition, CommonPageRequest pageRequest) {
 
     Pageable pageable = pageRequest.toPageable(Sort.by(Sort.Direction.DESC, "createdAt"));
 
-    // 1. 조건에 맞는 content 조회 (페이징 + 정렬 적용)
     List<Lecture> content =
         queryFactory
             .selectFrom(lecture)
@@ -51,7 +47,6 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
             .limit(pageable.getPageSize())
             .fetch();
 
-    // 2. 전체 건수 조회 (같은 조건)
     Long total =
         queryFactory
             .select(lecture.count())
@@ -65,9 +60,31 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
                 durationPolicyEq(condition.durationPolicy()))
             .fetchOne();
 
-    // 3. Page → CommonPageResponse 변환 + 매퍼 적용 (인프라 책임)
-    Page<Lecture> page = new PageImpl<>(content, pageable, total != null ? total : 0L);
-    return CommonPageResponse.of(page, mapper);
+    return new PageImpl<>(content, pageable, total != null ? total : 0L);
+  }
+
+  @Override
+  public Page<Lecture> findAllByInstructorId(UUID instructorId, CommonPageRequest pageRequest) {
+
+    Pageable pageable = pageRequest.toPageable(Sort.by(Sort.Direction.DESC, "createdAt"));
+
+    List<Lecture> content =
+        queryFactory
+            .selectFrom(lecture)
+            .where(lecture.instructor.instructorId.eq(instructorId))
+            .orderBy(lecture.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    Long total =
+        queryFactory
+            .select(lecture.count())
+            .from(lecture)
+            .where(lecture.instructor.instructorId.eq(instructorId))
+            .fetchOne();
+
+    return new PageImpl<>(content, pageable, total != null ? total : 0L);
   }
 
   // ── BooleanExpression (null 반환 시 where에서 자동 제외) ──

--- a/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureQueryRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/lecture/repository/LectureQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.goggles.lecture_service.infrastructure.lecture.repository;
 import static com.goggles.lecture_service.domain.lecture.QLecture.*;
 
 import com.goggles.common.pagination.CommonPageRequest;
+import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.LectureSearchCondition;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
@@ -12,6 +13,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -27,8 +29,10 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public Page<Lecture> findAllByCondition(
-      LectureSearchCondition condition, CommonPageRequest pageRequest) {
+  public <T> CommonPageResponse<T> findAllByCondition(
+      LectureSearchCondition condition,
+      CommonPageRequest pageRequest,
+      Function<Lecture, T> mapper) {
 
     Pageable pageable = pageRequest.toPageable(Sort.by(Sort.Direction.DESC, "createdAt"));
 
@@ -60,11 +64,13 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
                 durationPolicyEq(condition.durationPolicy()))
             .fetchOne();
 
-    return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    Page<Lecture> page = new PageImpl<>(content, pageable, total != null ? total : 0L);
+    return CommonPageResponse.of(page, mapper);
   }
 
   @Override
-  public Page<Lecture> findAllByInstructorId(UUID instructorId, CommonPageRequest pageRequest) {
+  public <T> CommonPageResponse<T> findAllByInstructorId(
+      UUID instructorId, CommonPageRequest pageRequest, Function<Lecture, T> mapper) {
 
     Pageable pageable = pageRequest.toPageable(Sort.by(Sort.Direction.DESC, "createdAt"));
 
@@ -84,7 +90,8 @@ public class LectureQueryRepositoryImpl implements LectureQueryRepository {
             .where(lecture.instructor.instructorId.eq(instructorId))
             .fetchOne();
 
-    return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    Page<Lecture> page = new PageImpl<>(content, pageable, total != null ? total : 0L);
+    return CommonPageResponse.of(page, mapper);
   }
 
   // ── BooleanExpression (null 반환 시 where에서 자동 제외) ──

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/MyLectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/MyLectureController.java
@@ -7,10 +7,8 @@ import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLect
 import com.goggles.lecture_service.application.enrollment.query.service.EnrollmentQueryService;
 import com.goggles.lecture_service.application.lecture.LectureService;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
-import com.goggles.lecture_service.presentation.lecture.dto.EnrolledLectureResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,27 +25,21 @@ public class MyLectureController {
 
   // 나의 수강 강의 목록 조회 (학생) - ACTIVE, EXPIRED 조회
   @GetMapping("/enrolled")
-  public CommonPageResponse<EnrolledLectureResponse> getEnrolledLectures(
+  public CommonPageResponse<EnrolledLectureResult> getEnrolledLectures(
       @RequestHeader("X-User-Id") UUID studentId,
       CommonPageRequest pageRequest,
       @RequestParam(required = false) String keyword,
       @RequestParam(required = false) String status,
       @RequestParam(required = false) String sort) {
 
-    Page<EnrolledLectureResult> results =
-        enrollmentQueryService.getEnrolledLectures(
-            EnrolledLectureQuery.of(studentId, keyword, status, sort, pageRequest));
-
-    return CommonPageResponse.of(results, EnrolledLectureResponse::from);
+    return enrollmentQueryService.getEnrolledLectures(
+        EnrolledLectureQuery.of(studentId, keyword, status, sort, pageRequest));
   }
 
   // 나의 강의 목록 조회 (강사) - 본인 소유 강의의 모든 상태 노출
   @GetMapping("/teaching")
   public CommonPageResponse<LectureSummary> getTeachingLectures(
       @RequestHeader("X-User-Id") UUID instructorId, CommonPageRequest pageRequest) {
-
-    Page<LectureSummary> results = lectureService.getTeachingLectures(instructorId, pageRequest);
-
-    return CommonPageResponse.of(results, lecture -> lecture);
+    return lectureService.getTeachingLectures(instructorId, pageRequest);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/MyLectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/MyLectureController.java
@@ -1,0 +1,35 @@
+package com.goggles.lecture_service.presentation.lecture;
+
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureSummary;
+import com.goggles.lecture_service.application.enrollment.query.service.EnrollmentQueryService;
+import com.goggles.lecture_service.application.lecture.LectureService;
+import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/me/lectures")
+@RequiredArgsConstructor
+public class MyLectureController {
+
+  private final EnrollmentQueryService enrollmentQueryService;
+  private final LectureService lectureService;
+
+  // 나의 수강 강의 목록 조회 (학생) - ACTIVE 수강만 노출
+  @GetMapping("/enrolled")
+  public List<EnrolledLectureSummary> getEnrolledLectures(
+      @RequestHeader("X-User-Id") UUID studentId) {
+    return enrollmentQueryService.getEnrolledLectures(studentId);
+  }
+
+  // 나의 강의 목록 조회 (강사) - 본인 소유 강의의 모든 상태 노출
+  @GetMapping("/teaching")
+  public List<LectureSummary> getTeachingLectures(@RequestHeader("X-User-Id") UUID instructorId) {
+    return lectureService.getTeachingLectures(instructorId);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/MyLectureController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/MyLectureController.java
@@ -1,15 +1,20 @@
 package com.goggles.lecture_service.presentation.lecture;
 
-import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureSummary;
+import com.goggles.common.pagination.CommonPageRequest;
+import com.goggles.common.pagination.CommonPageResponse;
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureQuery;
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureResult;
 import com.goggles.lecture_service.application.enrollment.query.service.EnrollmentQueryService;
 import com.goggles.lecture_service.application.lecture.LectureService;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
-import java.util.List;
+import com.goggles.lecture_service.presentation.lecture.dto.EnrolledLectureResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,16 +25,29 @@ public class MyLectureController {
   private final EnrollmentQueryService enrollmentQueryService;
   private final LectureService lectureService;
 
-  // 나의 수강 강의 목록 조회 (학생) - ACTIVE 수강만 노출
+  // 나의 수강 강의 목록 조회 (학생) - ACTIVE, EXPIRED 조회
   @GetMapping("/enrolled")
-  public List<EnrolledLectureSummary> getEnrolledLectures(
-      @RequestHeader("X-User-Id") UUID studentId) {
-    return enrollmentQueryService.getEnrolledLectures(studentId);
+  public CommonPageResponse<EnrolledLectureResponse> getEnrolledLectures(
+      @RequestHeader("X-User-Id") UUID studentId,
+      CommonPageRequest pageRequest,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) String status,
+      @RequestParam(required = false) String sort) {
+
+    Page<EnrolledLectureResult> results =
+        enrollmentQueryService.getEnrolledLectures(
+            EnrolledLectureQuery.of(studentId, keyword, status, sort, pageRequest));
+
+    return CommonPageResponse.of(results, EnrolledLectureResponse::from);
   }
 
   // 나의 강의 목록 조회 (강사) - 본인 소유 강의의 모든 상태 노출
   @GetMapping("/teaching")
-  public List<LectureSummary> getTeachingLectures(@RequestHeader("X-User-Id") UUID instructorId) {
-    return lectureService.getTeachingLectures(instructorId);
+  public CommonPageResponse<LectureSummary> getTeachingLectures(
+      @RequestHeader("X-User-Id") UUID instructorId, CommonPageRequest pageRequest) {
+
+    Page<LectureSummary> results = lectureService.getTeachingLectures(instructorId, pageRequest);
+
+    return CommonPageResponse.of(results, lecture -> lecture);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/EnrolledLectureResponse.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/lecture/dto/EnrolledLectureResponse.java
@@ -1,0 +1,34 @@
+package com.goggles.lecture_service.presentation.lecture.dto;
+
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureResult;
+import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
+import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record EnrolledLectureResponse(
+    UUID enrollmentId,
+    UUID lectureId,
+    String lectureTitle,
+    UUID instructorId,
+    String instructorName,
+    EnrollmentStatus status,
+    DurationPolicy durationPolicy,
+    LocalDateTime activatedAt,
+    LocalDateTime expiresAt,
+    LocalDateTime lastAccessedAt) {
+
+  public static EnrolledLectureResponse from(EnrolledLectureResult result) {
+    return new EnrolledLectureResponse(
+        result.enrollmentId(),
+        result.lectureId(),
+        result.lectureTitle(),
+        result.instructorId(),
+        result.instructorName(),
+        result.status(),
+        result.durationPolicy(),
+        result.activatedAt(),
+        result.expiresAt(),
+        result.lastAccessedAt());
+  }
+}

--- a/src/test/java/com/goggles/lecture_service/EnrollmentQueryServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentQueryServiceImplTest.java
@@ -1,0 +1,100 @@
+package com.goggles.lecture_service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.goggles.common.pagination.CommonPageRequest;
+import com.goggles.common.pagination.CommonPageResponse;
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureQuery;
+import com.goggles.lecture_service.application.enrollment.query.dto.EnrolledLectureResult;
+import com.goggles.lecture_service.application.enrollment.query.service.EnrollmentQueryServiceImpl;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentStatusException;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrolledLecturePageQuery;
+import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
+import java.util.UUID;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentQueryServiceImplTest {
+
+  @InjectMocks private EnrollmentQueryServiceImpl enrollmentQueryService;
+
+  @Mock private EnrollmentRepository enrollmentRepository;
+
+  private UUID studentId;
+  private CommonPageRequest pageRequest;
+
+  @BeforeEach
+  void setUp() {
+    studentId = UUID.randomUUID();
+    pageRequest = CommonPageRequest.of(0, 10);
+  }
+
+  @Nested
+  @DisplayName("학생 수강 강의 목록 조회")
+  class GetEnrolledLectures {
+
+    @Test
+    @DisplayName("성공: 수강 이력 페이지 위임 호출")
+    @SuppressWarnings("unchecked")
+    void getEnrolledLectures_success() {
+      // given
+      EnrolledLectureQuery query =
+          EnrolledLectureQuery.of(studentId, null, null, null, pageRequest);
+      CommonPageResponse<EnrolledLectureResult> expected = mock(CommonPageResponse.class);
+
+      when(enrollmentRepository.findEnrolledLectures(
+              any(EnrolledLecturePageQuery.class), any(Function.class)))
+          .thenReturn(expected);
+
+      // when
+      CommonPageResponse<EnrolledLectureResult> result =
+          enrollmentQueryService.getEnrolledLectures(query);
+
+      // then
+      assertThat(result).isSameAs(expected);
+      verify(enrollmentRepository, times(1))
+          .findEnrolledLectures(any(EnrolledLecturePageQuery.class), any(Function.class));
+    }
+
+    @Test
+    @DisplayName("실패: studentId 누락 시 EnrolledLectureQuery 생성에서 예외")
+    void enrolledLectureQuery_nullStudentId_throws() {
+      assertThatThrownBy(() -> EnrolledLectureQuery.of(null, null, null, null, pageRequest))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: pageRequest 누락 시 EnrolledLectureQuery 생성에서 예외")
+    void enrolledLectureQuery_nullPageRequest_throws() {
+      assertThatThrownBy(() -> EnrolledLectureQuery.of(studentId, null, null, null, null))
+          .isInstanceOf(InvalidEnrollmentFieldException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 검색 불가 status(RESERVE)는 예외")
+    void enrolledLectureQuery_reserveStatus_throws() {
+      assertThatThrownBy(
+              () -> EnrolledLectureQuery.of(studentId, null, "RESERVE", null, pageRequest))
+          .isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 검색 불가 status(CANCELED)는 예외")
+    void enrolledLectureQuery_canceledStatus_throws() {
+      assertThatThrownBy(
+              () -> EnrolledLectureQuery.of(studentId, null, "CANCELED", null, pageRequest))
+          .isInstanceOf(InvalidEnrollmentStatusException.class);
+    }
+  }
+}

--- a/src/test/java/com/goggles/lecture_service/LectureQueryServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/LectureQueryServiceImplTest.java
@@ -1,17 +1,23 @@
 package com.goggles.lecture_service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import com.goggles.common.pagination.CommonPageRequest;
+import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.application.lecture.query.dto.LectureDetail;
+import com.goggles.lecture_service.application.lecture.query.dto.LectureSummary;
 import com.goggles.lecture_service.application.lecture.query.service.LectureQueryServiceImpl;
 import com.goggles.lecture_service.domain.lecture.Lecture;
 import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.enums.LectureStatus;
 import com.goggles.lecture_service.domain.lecture.exception.LectureNotFoundException;
+import com.goggles.lecture_service.domain.lecture.repository.LectureQueryRepository;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,6 +34,7 @@ class LectureQueryServiceImplTest {
   @InjectMocks private LectureQueryServiceImpl lectureQueryService;
 
   @Mock private LectureRepository lectureRepository;
+  @Mock private LectureQueryRepository lectureQueryRepository;
 
   private UUID lectureId;
   private Lecture lecture;
@@ -120,6 +127,34 @@ class LectureQueryServiceImplTest {
       assertThat(result.chapters().get(0).title()).isEqualTo("챕터1");
       assertThat(result.chapters().get(1).sortOrder()).isEqualTo(2);
       verify(lectureRepository, times(1)).findByIdAndStatus(lectureId, LectureStatus.PUBLISHED);
+    }
+  }
+
+  @Nested
+  @DisplayName("강사 본인 강의 목록 조회")
+  class GetTeachingLectures {
+
+    @Test
+    @DisplayName("성공: 강사 본인 강의 페이지 위임 호출")
+    @SuppressWarnings("unchecked")
+    void getTeachingLectures_success() {
+      // given
+      UUID instructorId = UUID.randomUUID();
+      CommonPageRequest pageRequest = CommonPageRequest.of(0, 10);
+      CommonPageResponse<LectureSummary> expected = mock(CommonPageResponse.class);
+
+      when(lectureQueryRepository.findAllByInstructorId(
+              eq(instructorId), eq(pageRequest), any(Function.class)))
+          .thenReturn(expected);
+
+      // when
+      CommonPageResponse<LectureSummary> result =
+          lectureQueryService.getTeachingLectures(instructorId, pageRequest);
+
+      // then
+      assertThat(result).isSameAs(expected);
+      verify(lectureQueryRepository, times(1))
+          .findAllByInstructorId(eq(instructorId), eq(pageRequest), any(Function.class));
     }
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #7

### 💡 작업 내용
- 학생 본인의 수강 강의 목록 조회 API를 구현했습니다.
- 강사 본인의 등록 강의 목록 조회 API를 구현했습니다.
- 학생 내 강의 조회에 페이징, 검색, 상태 필터, 정렬 조건을 적용했습니다.
- 강사 내 강의 조회에 페이징을 적용했습니다.
- 기존 전체 강의 조회 Repository의 페이징 반환 구조를 `Page<Lecture>` 기반으로 정리했습니다.
- Repository는 조회 책임만 담당하고, DTO 변환은 Service/Controller 계층에서 처리하도록 구조를 통일했습니다.

### 🔍 변경 이유
- `RESERVE`는 결제 완료 전 임시 상태이므로 내 강의 목록에서 제외했습니다.
- `ACTIVE`는 현재 수강 가능한 강의이므로 내 강의 목록에 노출합니다.
- `EXPIRED`는 수강 기간은 끝났지만 사용자의 수강 이력이므로 함께 노출합니다.
- `CANCELED`는 취소/환불된 강의이므로 주문 내역에서 확인하는 것이 자연스럽다고 판단했습니다.
- 수강 이력은 누적될 수 있어 `List`가 아닌 페이징 기반 응답을 적용했습니다.
- 기존 조회 Repository가 `CommonPageResponse`와 mapper를 직접 다루던 구조를 `Page<Entity>` 반환 방식으로 정리하여 레이어 책임을 분리했습니다.

### 📝 리뷰 포인트
- 학생 내 강의 조회 대상 상태를 `ACTIVE + EXPIRED`로 제한한 정책이 적절한지 확인 부탁드립니다.
- `RESERVE`, `CANCELED`를 내 강의 목록에서 제외하고 주문 내역에서 다루는 방향이 괜찮은지 확인 부탁드립니다.
- Repository → Service → Controller 페이징 변환 흐름이 기존 컨벤션과 잘 맞는지 확인 부탁드립니다.
- 기존 전체 강의 조회의 응답은 유지하고 내부 Repository 반환 타입만 변경한 부분 확인 부탁드립니다.

### 🧠 기타 참고 사항
- 수강 기간은 `RESERVE` 생성 시점이 아니라 결제 완료 이벤트를 받아 `ACTIVE`로 전환되는 시점부터 카운트합니다.
- 영상 재생 권한은 `ACTIVE` 상태만 허용하는 기존 정책을 유지합니다.
- 강사 본인 강의 목록은 본인이 등록한 모든 상태의 강의를 노출합니다.
- 로그인 구현 전이므로 사용자 식별은 기존처럼 `X-User-Id` 헤더를 사용합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자가 등록한 강의 목록 조회 추가 (키워드·상태·정렬 지원, 검색 불가 상태 차단)
  * 강사가 자신의 강의 목록 조회 기능 추가
  * 조회 결과에 페이지네이션 및 정렬 옵션 적용
  * 응답에 강의·강사 정보, 상태, 유효기간, 최근 접속 등 상세 필드 포함

* **테스트**
  * 조회 서비스 및 입력 검증 관련 단위테스트 추가 (예외·위임 동작 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->