### PR TITLE
fix(lecture): 주문 수강 예약 API 연동 호환 처리(#29)

### DIFF
--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
@@ -24,7 +24,7 @@ public class InternalLectureEnrollmentController {
   private final EnrollmentCommandService enrollmentCommandService;
 
   // TODO: 권한 정책 확정 후 userRole 기반 내부 API 접근 제어 적용
-  @PostMapping("/reserve")
+  @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   public List<LectureEnrollmentReserveResponse> reserve(
       @RequestHeader("X-User-Id") UUID userId,

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentReserveRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentReserveRequest.java
@@ -1,5 +1,6 @@
 package com.goggles.lecture_service.presentation.enrollment.internal.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -7,7 +8,7 @@ import java.util.List;
 import java.util.UUID;
 
 public record LectureEnrollmentReserveRequest(
-    @NotEmpty(message = "productIds 는 비어있을 수 없습니다.")
+    @JsonAlias("lectureIds") @NotEmpty(message = "productIds 는 비어있을 수 없습니다.")
         List<@NotNull(message = "productId 는 필수입니다.") UUID> productIds) {
 
   public LectureEnrollmentReserveCommand toCommand(UUID userId) {


### PR DESCRIPTION
### 📌 관련 이슈
- close #29 

### 💡 작업 내용
- Order 서비스의 강의 주문 생성 흐름에서 Lecture 서비스의 수강 등록 예약 API가 정상 연동되도록 요청 경로 및 요청 필드 호환 처리를 진행합니다

### 🔍 변경 이유
- Order 서비스 호출 경로에 맞춰 수강 등록 예약 API 경로 수정
- Order 요청 필드 `lectureIds`를 Lecture에서 수신할 수 있도록 `@JsonAlias` 추가

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **API 변경사항**
  * 강의 등록 예약 엔드포인트의 경로 구조를 개선했습니다.
  * API 요청에서 강의 ID를 나타내는 필드명으로 대체 옵션을 추가하여 호환성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->