### PR TITLE
[REFACTOR] 중복 수강 검증 N+1 쿼리 배치 조회로 개선 

### DIFF
--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +42,12 @@ public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
     Map<UUID, Lecture> lectureMap =
         lectures.stream().collect(Collectors.toMap(Lecture::getId, l -> l));
 
-    // 2) 전체 검증
+    // 2) 중복 수강 일괄 조회 (N+1 방지)
+    Set<UUID> alreadyEnrolledLectureIds =
+        enrollmentRepository.findActiveLectureIdsByStudentAndLectureIdIn(
+            command.userId(), command.productIds());
+
+    // 3) 전체 검증
     for (UUID productId : command.productIds()) {
       Lecture lecture = lectureMap.get(productId);
 
@@ -53,12 +59,13 @@ public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
         throw new EnrollmentReserveFailedException(productId, ReserveFailReason.NOT_PUBLISHED);
       }
 
-      if (enrollmentRepository.existsActiveByStudentAndLecture(command.userId(), productId)) {
+      if (alreadyEnrolledLectureIds.contains(productId)) {
         throw new EnrollmentReserveFailedException(
             productId, ReserveFailReason.DUPLICATE_ENROLLMENT);
       }
     }
-    // 3) 검증 통과 후 Enrollment 저장
+
+    // 4) 검증 통과 후 Enrollment 저장
     List<LectureEnrollmentReserveResult> results = new ArrayList<>();
 
     for (UUID productId : command.productIds()) {

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
@@ -3,8 +3,10 @@ package com.goggles.lecture_service.domain.enrollment.repository;
 import com.goggles.common.pagination.CommonPageResponse;
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -18,8 +20,9 @@ public interface EnrollmentRepository {
 
   Optional<Enrollment> findByOrderIdAndLectureId(UUID orderId, UUID lectureId);
 
-  // 동일 학생 + 동일 강의에 RESERVE/ACTIVE 인 enrollment 존재 여부. 중복 수강 검증용
-  boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId);
+  // 학생이 이미 RESERVE/ACTIVE 상태로 보유한 lectureId 집합 반환 / 중복 수강 검증용 (배치)
+  Set<UUID> findActiveLectureIdsByStudentAndLectureIdIn(
+      UUID studentId, Collection<UUID> lectureIds);
 
   List<Enrollment> findAllByOrderId(UUID orderId);
 

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentJpaRepository.java
@@ -21,13 +21,13 @@ public interface EnrollmentJpaRepository extends JpaRepository<Enrollment, UUID>
       @Param("orderId") UUID orderId, @Param("lectureId") UUID lectureId);
 
   @Query(
-      "select count(e) > 0 from Enrollment e "
+      "select e.lectureSnapshot.lectureId from Enrollment e "
           + "where e.studentId = :studentId "
-          + "and e.lectureSnapshot.lectureId = :lectureId "
+          + "and e.lectureSnapshot.lectureId in :lectureIds "
           + "and e.status in :statuses")
-  boolean existsByStudentAndLectureAndStatusIn(
+  List<UUID> findLectureIdsByStudentAndLectureIdInAndStatusIn(
       @Param("studentId") UUID studentId,
-      @Param("lectureId") UUID lectureId,
+      @Param("lectureIds") Collection<UUID> lectureIds,
       @Param("statuses") Collection<EnrollmentStatus> statuses);
 
   List<Enrollment> findAllByOrderId(UUID orderId);

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -6,7 +6,9 @@ import com.goggles.lecture_service.domain.enrollment.enums.EnrollmentStatus;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrolledLecturePageQuery;
 import com.goggles.lecture_service.domain.enrollment.repository.EnrollmentRepository;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -47,9 +49,14 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
   }
 
   @Override
-  public boolean existsActiveByStudentAndLecture(UUID studentId, UUID lectureId) {
-    return jpaRepository.existsByStudentAndLectureAndStatusIn(
-        studentId, lectureId, ACTIVE_OR_RESERVED);
+  public Set<UUID> findActiveLectureIdsByStudentAndLectureIdIn(
+      UUID studentId, Collection<UUID> lectureIds) {
+    if (lectureIds == null || lectureIds.isEmpty()) {
+      return Set.of();
+    }
+    return new HashSet<>(
+        jpaRepository.findLectureIdsByStudentAndLectureIdInAndStatusIn(
+            studentId, lectureIds, ACTIVE_OR_RESERVED));
   }
 
   @Override

--- a/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
@@ -24,6 +24,7 @@ import com.goggles.lecture_service.domain.lecture.enums.DurationPolicy;
 import com.goggles.lecture_service.domain.lecture.repository.LectureRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -61,8 +62,9 @@ class EnrollmentCommandServiceImplTest {
     void reserve_singleProduct_success() {
       Lecture lecture = publishedLecture();
       when(lectureRepository.findAllByIdIn(List.of(lecture.getId()))).thenReturn(List.of(lecture));
-      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, lecture.getId()))
-          .thenReturn(false);
+      when(enrollmentRepository.findActiveLectureIdsByStudentAndLectureIdIn(
+              userId, List.of(lecture.getId())))
+          .thenReturn(Set.of());
       when(enrollmentRepository.save(any(Enrollment.class))).thenAnswer(inv -> inv.getArgument(0));
 
       List<LectureEnrollmentReserveResult> results =
@@ -81,10 +83,8 @@ class EnrollmentCommandServiceImplTest {
       List<UUID> productIds = List.of(lecture1.getId(), lecture2.getId());
 
       when(lectureRepository.findAllByIdIn(productIds)).thenReturn(List.of(lecture1, lecture2));
-      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, lecture1.getId()))
-          .thenReturn(false);
-      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, lecture2.getId()))
-          .thenReturn(false);
+      when(enrollmentRepository.findActiveLectureIdsByStudentAndLectureIdIn(userId, productIds))
+          .thenReturn(Set.of());
       when(enrollmentRepository.save(any(Enrollment.class))).thenAnswer(inv -> inv.getArgument(0));
 
       List<LectureEnrollmentReserveResult> results =
@@ -112,8 +112,8 @@ class EnrollmentCommandServiceImplTest {
       List<UUID> productIds = List.of(published.getId(), draft.getId());
 
       when(lectureRepository.findAllByIdIn(productIds)).thenReturn(List.of(published, draft));
-      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, published.getId()))
-          .thenReturn(false);
+      when(enrollmentRepository.findActiveLectureIdsByStudentAndLectureIdIn(userId, productIds))
+          .thenReturn(Set.of());
 
       assertThatThrownBy(
               () -> service.reserve(new LectureEnrollmentReserveCommand(productIds, userId)))
@@ -157,8 +157,9 @@ class EnrollmentCommandServiceImplTest {
     void reserve_duplicate_throws() {
       Lecture lecture = publishedLecture();
       when(lectureRepository.findAllByIdIn(List.of(lecture.getId()))).thenReturn(List.of(lecture));
-      when(enrollmentRepository.existsActiveByStudentAndLecture(userId, lecture.getId()))
-          .thenReturn(true);
+      when(enrollmentRepository.findActiveLectureIdsByStudentAndLectureIdIn(
+              userId, List.of(lecture.getId())))
+          .thenReturn(Set.of(lecture.getId()));
 
       assertThatThrownBy(
               () ->


### PR DESCRIPTION
### 📌 관련 이슈
- close #24
 
### 💡 작업 내용
- `EnrollmentCommandServiceImpl.reserve()` 메서드의 중복 수강 검증을 배치 조회 방식으로 변경했습니다.
- 기존 단건 메서드 `existsActiveByStudentAndLecture`를 제거하고, 배치 메서드 `findActiveLectureIdsByStudentAndLectureIdIn(UUID, Collection<UUID>)`를 추가했습니다.
- 도메인 인터페이스 반환 타입은 `Set<UUID>`로 두어 `contains()` 호출이 O(1)로 동작하도록 했습니다.
- JPA Repository는 `List<UUID>`를 반환하고, Repository 구현체에서 Set으로 변환합니다.

### 🔍 변경 이유
- N개 productIds → DB 호출 N번 → 1번으로 감소시켰습니다.
- 단건 메서드가 사실상 루프 안에서만 사용되어 안티패턴을 유발하던 구조를, 배치 메서드 단일화로 정리했습니다.
- 동일한 검증 로직(RESERVE/ACTIVE 상태 체크)이 두 메서드에 분산되지 않도록 했습니다.
- 
### 📝 리뷰 포인트 (선택)
- 단건 메서드를 제거하고 배치 메서드만 유지한 결정이 적절한지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- 동시성 (같은 학생이 동시에 같은 강의를 reserve) 처리는 본 PR 범위가 아니며, 별도 이슈로 분리할 예정입니다.
- 베이스 브랜치는 #39와의 의존 관계상 `feature/39-order-cancelled-consumer`로 두었습니다. #39 머지 후 자동으로 dev에 반영됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 강좌 등록 시 중복 검사 로직을 최적화했습니다. 개별 강좌 확인 방식에서 일괄 조회 방식으로 변경되어 등록 처리 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->