### PR TITLE
[FEAT] 주문 결제 실패 rollback api 구현

### DIFF
--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentRollbackCommand.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/dto/LectureEnrollmentRollbackCommand.java
@@ -1,0 +1,30 @@
+package com.goggles.lecture_service.application.enrollment.command.dto;
+
+import com.goggles.lecture_service.domain.enrollment.exception.EnrollmentErrorCode;
+import com.goggles.lecture_service.domain.enrollment.exception.InvalidEnrollmentFieldException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+public record LectureEnrollmentRollbackCommand(List<UUID> enrollmentIds, UUID userId) {
+
+  public LectureEnrollmentRollbackCommand {
+    if (enrollmentIds == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_IDS_REQUIRED);
+    }
+    if (enrollmentIds.isEmpty()) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_IDS_EMPTY);
+    }
+    if (enrollmentIds.stream().anyMatch(id -> id == null)) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ID_REQUIRED);
+    }
+    if (new HashSet<>(enrollmentIds).size() != enrollmentIds.size()) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_IDS_DUPLICATED);
+    }
+    if (userId == null) {
+      throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_USER_ID_REQUIRED);
+    }
+
+    enrollmentIds = List.copyOf(enrollmentIds);
+  }
+}

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandService.java
@@ -4,6 +4,7 @@ import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnr
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCompleteCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentRollbackCommand;
 import java.util.List;
 
 public interface EnrollmentCommandService {
@@ -13,4 +14,6 @@ public interface EnrollmentCommandService {
   void complete(LectureEnrollmentCompleteCommand command);
 
   void cancel(LectureEnrollmentCancelCommand command);
+
+  void rollback(LectureEnrollmentRollbackCommand command);
 }

--- a/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
+++ b/src/main/java/com/goggles/lecture_service/application/enrollment/command/service/EnrollmentCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnr
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCompleteCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentRollbackCommand;
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import com.goggles.lecture_service.domain.enrollment.LectureSnapshot;
 import com.goggles.lecture_service.domain.enrollment.enums.ReserveFailReason;
@@ -136,5 +137,35 @@ public class EnrollmentCommandServiceImpl implements EnrollmentCommandService {
     for (UUID enrollmentId : command.enrollmentIds()) {
       enrollmentMap.get(enrollmentId).cancel();
     }
+  }
+
+  @Override
+  public void rollback(LectureEnrollmentRollbackCommand command) {
+    List<Enrollment> enrollments = enrollmentRepository.findAllByIdIn(command.enrollmentIds());
+
+    if (enrollments.isEmpty()) {
+      log.info(
+          "Enrollment rollback skipped (all enrollments missing). userId={}, requested={}",
+          command.userId(),
+          command.enrollmentIds().size());
+      return;
+    }
+
+    // 존재하는 enrollment 에 대해서만 소유권 + 상태 검증
+    for (Enrollment enrollment : enrollments) {
+      if (!enrollment.getStudentId().equals(command.userId())) {
+        throw new EnrollmentNotOwnedException(EnrollmentErrorCode.ENROLLMENT_NOT_OWNED);
+      }
+      enrollment.validateRollbackable();
+    }
+
+    List<UUID> deletableIds = enrollments.stream().map(Enrollment::getId).toList();
+    enrollmentRepository.deleteAllByIdIn(deletableIds);
+
+    log.info(
+        "Enrollment rollback processed. userId={}, requested={}, deleted={}",
+        command.userId(),
+        command.enrollmentIds().size(),
+        deletableIds.size());
   }
 }

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/Enrollment.java
@@ -177,6 +177,14 @@ public class Enrollment extends BaseAudit {
           EnrollmentErrorCode.ENROLLMENT_DURATION_POLICY_REQUIRED);
   }
 
+  // 결제 실패 보상 트랙잭션
+  public void validateRollbackable() {
+    if (this.status != EnrollmentStatus.RESERVE) {
+      throw new InvalidEnrollmentStatusException(
+          EnrollmentErrorCode.ENROLLMENT_INVALID_STATUS_FOR_ROLLBACK);
+    }
+  }
+
   private static void validateOrderId(UUID orderId) {
     if (orderId == null) {
       throw new InvalidEnrollmentFieldException(EnrollmentErrorCode.ENROLLMENT_ORDER_ID_REQUIRED);

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -22,6 +22,7 @@ public enum EnrollmentErrorCode {
   ENROLLMENT_INVALID_STATUS_FOR_CANCEL("RESERVE 또는 ACTIVE 상태에서만 취소할 수 있습니다."),
   ENROLLMENT_INVALID_STATUS_FOR_EXPIRE("ACTIVE 상태에서만 만료 처리할 수 있습니다."),
   ENROLLMENT_INVALID_STATUS_FOR_ACCESS("ACTIVE 상태에서만 강의에 접근할 수 있습니다."),
+  ENROLLMENT_INVALID_STATUS_FOR_ROLLBACK("RESERVE 상태에서만 롤백할 수 있습니다."),
 
   // 강의 검증
   ENROLLMENT_LECTURE_NOT_PUBLISHED("판매 중인 강의가 아닙니다."),

--- a/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/goggles/lecture_service/domain/enrollment/repository/EnrollmentRepository.java
@@ -30,4 +30,6 @@ public interface EnrollmentRepository {
       EnrolledLecturePageQuery query, Function<Enrollment, T> mapper);
 
   List<UUID> findExpirationTargetIds(LocalDateTime now, int limit);
+
+  void deleteAllByIdIn(List<UUID> ids);
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -77,4 +77,12 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
         now,
         PageRequest.of(0, limit));
   }
+
+  @Override
+  public void deleteAllByIdIn(List<UUID> ids) {
+    if (ids == null || ids.isEmpty()) {
+      return;
+    }
+    jpaRepository.deleteAllByIdInBatch(ids);
+  }
 }

--- a/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/enrollment/repository/EnrollmentRepositoryImpl.java
@@ -83,6 +83,8 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
     if (ids == null || ids.isEmpty()) {
       return;
     }
+    // 결제 실패 보상 트랜잭션: RESERVE 상태 데이터는 확정된 적 없으므로
+    // 소프트 삭제 대신 물리 삭제로 완전히 제거합니다.
     jpaRepository.deleteAllByIdInBatch(ids);
   }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/InternalLectureEnrollmentController.java
@@ -4,6 +4,7 @@ import com.goggles.lecture_service.application.enrollment.command.service.Enroll
 import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentCancelRequest;
 import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveRequest;
 import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentReserveResponse;
+import com.goggles.lecture_service.presentation.enrollment.internal.dto.LectureEnrollmentRollbackRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -44,5 +45,14 @@ public class InternalLectureEnrollmentController {
       @Valid @RequestBody LectureEnrollmentCancelRequest request) {
 
     enrollmentCommandService.cancel(request.toCommand(userId));
+  }
+
+  @PostMapping("/rollback")
+  @ResponseStatus(HttpStatus.OK)
+  public void rollback(
+      @RequestHeader("X-User-Id") UUID userId,
+      @Valid @RequestBody LectureEnrollmentRollbackRequest request) {
+
+    enrollmentCommandService.rollback(request.toCommand(userId));
   }
 }

--- a/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentRollbackRequest.java
+++ b/src/main/java/com/goggles/lecture_service/presentation/enrollment/internal/dto/LectureEnrollmentRollbackRequest.java
@@ -1,0 +1,16 @@
+package com.goggles.lecture_service.presentation.enrollment.internal.dto;
+
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentRollbackCommand;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+public record LectureEnrollmentRollbackRequest(
+    @NotEmpty(message = "enrollmentIds 는 비어있을 수 없습니다.")
+        List<@NotNull(message = "enrollmentId 는 필수입니다.") UUID> enrollmentIds) {
+
+  public LectureEnrollmentRollbackCommand toCommand(UUID userId) {
+    return new LectureEnrollmentRollbackCommand(enrollmentIds, userId);
+  }
+}

--- a/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
+++ b/src/test/java/com/goggles/lecture_service/EnrollmentCommandServiceImplTest.java
@@ -8,6 +8,7 @@ import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnr
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentCompleteCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveCommand;
 import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentReserveResult;
+import com.goggles.lecture_service.application.enrollment.command.dto.LectureEnrollmentRollbackCommand;
 import com.goggles.lecture_service.application.enrollment.command.service.EnrollmentCommandServiceImpl;
 import com.goggles.lecture_service.domain.enrollment.Enrollment;
 import com.goggles.lecture_service.domain.enrollment.LectureSnapshot;
@@ -359,6 +360,103 @@ class EnrollmentCommandServiceImplTest {
               () ->
                   service.complete(new LectureEnrollmentCompleteCommand(orderId, List.of(missing))))
           .isInstanceOf(EnrollmentNotFoundException.class);
+    }
+
+    // 헬퍼
+    private Enrollment reservedEnrollment(UUID studentId) {
+      LectureSnapshot snapshot =
+          LectureSnapshot.of(UUID.randomUUID(), "스프링 강의", UUID.randomUUID(), "홍길동");
+      return Enrollment.reserve(snapshot, studentId, DurationPolicy.DAYS_365);
+    }
+  }
+
+  @Nested
+  @DisplayName("결제 실패 보상 트랜잭션 롤백")
+  class Rollback {
+
+    @Test
+    @DisplayName("성공: 단건 RESERVE enrollment 물리 삭제")
+    void rollback_singleReserve_success() {
+      Enrollment enrollment = reservedEnrollment(userId);
+      UUID enrollmentId = enrollment.getId();
+      when(enrollmentRepository.findAllByIdIn(List.of(enrollmentId)))
+          .thenReturn(List.of(enrollment));
+
+      service.rollback(new LectureEnrollmentRollbackCommand(List.of(enrollmentId), userId));
+
+      verify(enrollmentRepository).deleteAllByIdIn(List.of(enrollmentId));
+    }
+
+    @Test
+    @DisplayName("성공: 다건 RESERVE enrollment 물리 삭제")
+    void rollback_multipleReserve_success() {
+      Enrollment a = reservedEnrollment(userId);
+      Enrollment b = reservedEnrollment(userId);
+      List<UUID> ids = List.of(a.getId(), b.getId());
+      when(enrollmentRepository.findAllByIdIn(ids)).thenReturn(List.of(a, b));
+
+      service.rollback(new LectureEnrollmentRollbackCommand(ids, userId));
+
+      verify(enrollmentRepository).deleteAllByIdIn(ids);
+    }
+
+    @Test
+    @DisplayName("성공(멱등성): 모든 enrollmentId 미존재 시 삭제 호출 없이 종료")
+    void rollback_allMissing_idempotentSkip() {
+      UUID missing = UUID.randomUUID();
+      when(enrollmentRepository.findAllByIdIn(List.of(missing))).thenReturn(List.of());
+
+      service.rollback(new LectureEnrollmentRollbackCommand(List.of(missing), userId));
+
+      verify(enrollmentRepository, never()).deleteAllByIdIn(anyList());
+    }
+
+    @Test
+    @DisplayName("성공(멱등성): 일부 enrollmentId 미존재 시 존재하는 것만 삭제")
+    void rollback_partiallyMissing_deletesExistingOnly() {
+      Enrollment existing = reservedEnrollment(userId);
+      UUID missing = UUID.randomUUID();
+      List<UUID> requested = List.of(existing.getId(), missing);
+      when(enrollmentRepository.findAllByIdIn(requested)).thenReturn(List.of(existing));
+
+      service.rollback(new LectureEnrollmentRollbackCommand(requested, userId));
+
+      verify(enrollmentRepository).deleteAllByIdIn(List.of(existing.getId()));
+    }
+
+    @Test
+    @DisplayName("실패: 다른 학생 소유 enrollment 롤백 시도")
+    void rollback_notOwned_throws() {
+      UUID otherUser = UUID.randomUUID();
+      Enrollment otherUserEnrollment = reservedEnrollment(otherUser);
+      when(enrollmentRepository.findAllByIdIn(List.of(otherUserEnrollment.getId())))
+          .thenReturn(List.of(otherUserEnrollment));
+
+      assertThatThrownBy(
+              () ->
+                  service.rollback(
+                      new LectureEnrollmentRollbackCommand(
+                          List.of(otherUserEnrollment.getId()), userId)))
+          .isInstanceOf(EnrollmentNotOwnedException.class);
+
+      verify(enrollmentRepository, never()).deleteAllByIdIn(anyList());
+    }
+
+    @Test
+    @DisplayName("실패: ACTIVE 상태(결제 성공) enrollment 롤백 시도 차단")
+    void rollback_activeStatus_throws() {
+      Enrollment enrollment = reservedEnrollment(userId);
+      enrollment.complete(LocalDateTime.now(), UUID.randomUUID()); // RESERVE → ACTIVE
+      when(enrollmentRepository.findAllByIdIn(List.of(enrollment.getId())))
+          .thenReturn(List.of(enrollment));
+
+      assertThatThrownBy(
+              () ->
+                  service.rollback(
+                      new LectureEnrollmentRollbackCommand(List.of(enrollment.getId()), userId)))
+          .isInstanceOf(InvalidEnrollmentStatusException.class);
+
+      verify(enrollmentRepository, never()).deleteAllByIdIn(anyList());
     }
 
     // 헬퍼


### PR DESCRIPTION
### 📌 관련 이슈
- close #41

### 💡 작업 내용
- `POST /internal/v1/lectures-enrollment/rollback` 엔드포인트 추가
- RESERVE 상태 enrollment 물리 삭제 (`deleteAllByIdInBatch`)
- 소유권 + 상태 검증 후 삭제 (ACTIVE 는 결제 성공이므로 차단)
- 미존재 enrollmentId 는 무시하는 멱등성 처리
- 단위 테스트 추가

### 🔍 변경 이유
- Order Service 결제 실패 시 보상 트랜잭션을 위한 Feign API 필요
- 결제 실패는 주문 성립 전이므로 cancel(상태 변경)이 아닌 물리 삭제로 처리
- Feign 재시도/네트워크 장애 대비로 멱등성 보장

### 📝 리뷰 포인트 (선택)
- `EnrollmentCommandServiceImpl#rollback` 의 멱등성 정책 (미존재 ID 무시)
- ACTIVE 상태 차단 검증 위치 (도메인 `validateRollbackable`)

### 🧠 기타 참고 사항
- `X-User-Role` 헤더는 받지 않음 (내부 시스템 간 호출)
- cancel API 와 흐름은 유사하나 종착점이 상태 변경 vs 물리 삭제로 다름

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 예약(RESERVE) 상태인 강의 신청을 한 번에 롤백(삭제)할 수 있는 내부 롤백 API가 추가되었습니다. 본인 신청만 롤백 가능하며 중복 요청은 거부됩니다.
* **동작 개선**
  * 요청 유효성 검증 강화(빈/널 검사, 중복 검사) 및 존재하는 항목만 부분적으로 처리하는 멱등성 보장.
* **테스트**
  * 롤백 동작(단건/다건/부분/권한/상태 검증)에 대한 단위 테스트가 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/9oogle/lecture-service/pull/43)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->