### PR TITLE
[FIX] Kafka consumer 토픽 placeholder 키 정합성 수정

### DIFF
--- a/src/main/java/com/goggles/lecture_service/infrastructure/messaging/consumer/LectureOrderCancelConsumer.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/messaging/consumer/LectureOrderCancelConsumer.java
@@ -24,7 +24,7 @@ public class LectureOrderCancelConsumer {
   private final EnrollmentCommandService enrollmentCommandService;
   private final ObjectMapper objectMapper;
 
-  @KafkaListener(topics = "${topics.order.cancelled}", groupId = GROUP_NAME)
+  @KafkaListener(topics = "${topics.order.lecture-cancelled}", groupId = GROUP_NAME)
   @IdempotentConsumer(GROUP_NAME)
   public void consume(ConsumerRecord<String, String> record) {
     log.info(

--- a/src/main/java/com/goggles/lecture_service/infrastructure/messaging/consumer/LectureOrderCompletionConsumer.java
+++ b/src/main/java/com/goggles/lecture_service/infrastructure/messaging/consumer/LectureOrderCompletionConsumer.java
@@ -24,7 +24,7 @@ public class LectureOrderCompletionConsumer {
   private final EnrollmentCommandService enrollmentCommandService;
   private final ObjectMapper objectMapper;
 
-  @KafkaListener(topics = "${topics.order.completed}", groupId = GROUP_NAME)
+  @KafkaListener(topics = "${topics.order.lecture-completed}", groupId = GROUP_NAME)
   @IdempotentConsumer(GROUP_NAME)
   public void consume(ConsumerRecord<String, String> record) {
     log.info(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,7 +3,9 @@ spring:
     name: lecture-service
   profiles:
     active: ${SPRING_PROFILES_ACTIVE}
-    include: topics
+    include:
+      - topics
+      - kafka
   config:
     import:
       - optional:file:.env[.properties]


### PR DESCRIPTION

### 💡 작업 내용
- `LectureOrderCancelConsumer`: `${topics.order.cancelled}` → `${topics.order.lecture-cancelled}`
- `OrderEnrollmentCompletionConsumer`: `${topics.order.completed}` → `${topics.order.lecture-completed}`
- `application.yaml`의 `profiles.include`에 `kafka` 추가

### 🔍 변경 이유
- Kafka consumer의 `@KafkaListener` 토픽 placeholder가 `application-topics.yaml`의 키와 일치하지 않아 부팅 시 `Could not resolve placeholder` 에러 발생
- Spring Boot 2.4+ 에서는 `spring.profiles.include`를 profile-specific 위치(Config Server 응답 포함)에서 사용할 수 없어, 로컬 `application.yaml`에서 관리하도록 이동

### 🧠 기타 참고 사항
- `project-configs` 레포의 `lecture-service/application.yaml`에서 `spring.profiles.include: kafka` 두 줄 제거 (별도 커밋으로 push 완료)