### PR TITLE
[Chore] lecture-service dev 환경 자동 배포 구축 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -209,7 +209,7 @@ jobs:
             }
 
             upsert_env IMAGE_TAG "$NEW_TAG"
-            upsert_env SPRING_DATASOURCE_URL "jdbc:postgresql://${{ secrets.DB_URL }}/lecture_db?currentSchema=lecture_db"
+            upsert_env SPRING_DATASOURCE_URL "jdbc:postgresql://${{ secrets.DB_URL }}/lecture_db"
             upsert_env DB_USERNAME "${{ secrets.DB_USERNAME }}"
             upsert_env DB_PASSWORD "${{ secrets.DB_PASSWORD }}"
             upsert_env EUREKA_CLIENT_SERVICEURL_DEFAULTZONE "http://${{ secrets.VM_INTERNAL_HOST }}:9001/eureka/"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ permissions:
 
 on:
   push:
-    branches: ["dev", "main","chore/44-lecture-service-dev-deploy"]
+    branches: ["dev", "main", "chore/44-lecture-service-dev-deploy"]
   workflow_dispatch:
 
 env:
@@ -23,6 +23,7 @@ jobs:
           SECRET_VM_HOST: ${{ secrets.VM_HOST }}
           SECRET_VM_SSH_KEY: ${{ secrets.VM_SSH_KEY }}
           SECRET_GCP_PROJECT_NUMBER: ${{ secrets.GCP_PROJECT_NUMBER }}
+          SECRET_TRUST_STORE_PASSWORD: ${{ secrets.TRUST_STORE_PASSWORD }}
         run: |
           echo "=== Variables ==="
           echo "GAR_LOCATION     : ${{ vars.GAR_LOCATION }}"
@@ -36,9 +37,10 @@ jobs:
           echo "HEALTH_CHECK_PORT: ${{ vars.HEALTH_CHECK_PORT }}"
           echo ""
           echo "=== Secrets (존재 여부만 확인) ==="
-          [ -n "$SECRET_VM_HOST"            ] && echo "VM_HOST            : ✅" || echo "VM_HOST            : ❌ 누락"
-          [ -n "$SECRET_VM_SSH_KEY"         ] && echo "VM_SSH_KEY         : ✅" || echo "VM_SSH_KEY         : ❌ 누락"
-          [ -n "$SECRET_GCP_PROJECT_NUMBER" ] && echo "GCP_PROJECT_NUMBER : ✅" || echo "GCP_PROJECT_NUMBER : ❌ 누락"
+          [ -n "$SECRET_VM_HOST"             ] && echo "VM_HOST             : ✅" || echo "VM_HOST             : ❌ 누락"
+          [ -n "$SECRET_VM_SSH_KEY"          ] && echo "VM_SSH_KEY          : ✅" || echo "VM_SSH_KEY          : ❌ 누락"
+          [ -n "$SECRET_GCP_PROJECT_NUMBER"  ] && echo "GCP_PROJECT_NUMBER  : ✅" || echo "GCP_PROJECT_NUMBER  : ❌ 누락"
+          [ -n "$SECRET_TRUST_STORE_PASSWORD"] && echo "TRUST_STORE_PASSWORD: ✅" || echo "TRUST_STORE_PASSWORD: ❌ 누락"
           echo ""
 
           MISSING=()
@@ -54,6 +56,7 @@ jobs:
           [ -z "$SECRET_VM_HOST"               ] && MISSING+=("secrets.VM_HOST")
           [ -z "$SECRET_VM_SSH_KEY"            ] && MISSING+=("secrets.VM_SSH_KEY")
           [ -z "$SECRET_GCP_PROJECT_NUMBER"    ] && MISSING+=("secrets.GCP_PROJECT_NUMBER")
+          [ -z "$SECRET_TRUST_STORE_PASSWORD"  ] && MISSING+=("secrets.TRUST_STORE_PASSWORD")
 
           if [ ${#MISSING[@]} -gt 0 ]; then
             echo "=== 누락된 변수 ==="
@@ -130,11 +133,9 @@ jobs:
           service_account: ${{ vars.GCP_SA_EMAIL }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
-
       - name: Configure Docker for Artifact Registry
         run: |
           gcloud auth configure-docker ${{ vars.GAR_LOCATION }}-docker.pkg.dev --quiet
-
 
       - name: Build and push image
         run: |
@@ -169,7 +170,7 @@ jobs:
           port: ${{ vars.VM_SSH_PORT }}
           key: ${{ secrets.VM_SSH_KEY }}
           source: "${{ steps.vars.outputs.compose }}"
-          target: "${{ vars.APP_DIR }}"
+          target: "${{ vars.APP_DIR }}/${{ vars.SERVICE_NAME }}"
 
       - name: Deploy to VM
         uses: appleboy/ssh-action@v1
@@ -181,12 +182,13 @@ jobs:
           script: |
             set -e
 
-            APP_DIR="${{ vars.APP_DIR }}"
+            APP_DIR="${{ vars.APP_DIR }}/${{ vars.SERVICE_NAME }}"
             SERVICE="${{ vars.SERVICE_NAME }}"
             NEW_TAG="${{ github.sha }}"
             export IMAGE="${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/${{ vars.SERVICE_NAME }}"
             ENV_FILE="$APP_DIR/.env"
 
+            mkdir -p $APP_DIR
             cd $APP_DIR
 
             # 롤백용 이전 태그 저장
@@ -207,38 +209,22 @@ jobs:
             }
 
             upsert_env IMAGE_TAG "$NEW_TAG"
-            upsert_env SPRING_DATASOURCE_URL "${{ secrets.DB_URL }}/${{ vars.DB_SCHEMA }}"
-            upsert_env EUREKA_CLIENT_SERVICEURL_DEFAULTZONE "http://${{ secrets.VM_HOST }}:9001/eureka/"
+            upsert_env SPRING_DATASOURCE_URL "jdbc:postgresql://${{ secrets.DB_URL }}/lecture_db?currentSchema=lecture_db"
+            upsert_env DB_USERNAME "${{ secrets.DB_USERNAME }}"
+            upsert_env DB_PASSWORD "${{ secrets.DB_PASSWORD }}"
+            upsert_env EUREKA_CLIENT_SERVICEURL_DEFAULTZONE "http://${{ secrets.VM_INTERNAL_HOST }}:9001/eureka/"
             upsert_env KAFKA_BOOTSTRAP_SERVERS "${{ secrets.KAFKA_1_INTERNAL_IP }}:9092,${{ secrets.KAFKA_2_INTERNAL_IP }}:9092,${{ secrets.KAFKA_3_INTERNAL_IP }}:9092"
+            upsert_env TRUST_STORE_PASSWORD "${{ secrets.TRUST_STORE_PASSWORD }}"
             upsert_env MONITORING_HOST "${{ secrets.MONITORING_VM_HOST }}"
 
-            # Kafka SSL truststore 복원
-            mkdir -p $APP_DIR/ssl
+            # config server는 Eureka 디스커버리로 찾으므로 URI 직접 지정 불필요
+            sed -i '/^SPRING_CLOUD_CONFIG_URI=/d' "$ENV_FILE" 2>/dev/null || true
 
-            TRUSTSTORE_B64="${{ secrets.TRUSTSTORE_JKS_B64 }}"
-            echo "[SSL] TRUSTSTORE_JKS_B64 secret 길이: ${#TRUSTSTORE_B64}"
-            if [ -z "$TRUSTSTORE_B64" ]; then
-              echo "[SSL] ❌ TRUSTSTORE_JKS_B64 secret이 비어있음"
+            # SSL truststore는 VM 공용 경로에 직접 배치 (/home/deploy/ssl/kafka.truststore.jks)
+            if [ ! -f "/home/deploy/ssl/kafka.truststore.jks" ]; then
+              echo "[SSL] ❌ /home/deploy/ssl/kafka.truststore.jks 파일 없음 — VM에 직접 배치 필요"
               exit 1
             fi
-
-            echo "$TRUSTSTORE_B64" | base64 -d > $APP_DIR/ssl/kafka.truststore.jks
-
-            echo "[SSL] 파일 경로: $APP_DIR/ssl/kafka.truststore.jks"
-            if [ -f "$APP_DIR/ssl/kafka.truststore.jks" ]; then
-              FILE_SIZE=$(stat -c%s "$APP_DIR/ssl/kafka.truststore.jks")
-              echo "[SSL] ✅ 파일 존재 (크기: ${FILE_SIZE} bytes)"
-              if [ "$FILE_SIZE" -eq 0 ]; then
-                echo "[SSL] ❌ 파일이 비어있음 — base64 디코딩 실패"
-                exit 1
-              fi
-            else
-              echo "[SSL] ❌ 파일 생성 실패"
-              exit 1
-            fi
-
-            echo "[SSL] ssl 디렉토리 내용:"
-            ls -lh $APP_DIR/ssl/
 
             # 새 이미지 pull & 재시작
             COMPOSE_FILE="${{ steps.vars.outputs.compose }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,12 @@ jobs:
         env:
           SECRET_VM_HOST: ${{ secrets.VM_HOST }}
           SECRET_VM_SSH_KEY: ${{ secrets.VM_SSH_KEY }}
+          SECRET_GCP_PROJECT_NUMBER: ${{ secrets.GCP_PROJECT_NUMBER }}
         run: |
           echo "=== Variables ==="
           echo "GAR_LOCATION     : ${{ vars.GAR_LOCATION }}"
           echo "GCP_PROJECT_ID   : ${{ vars.GCP_PROJECT_ID }}"
+          echo "GCP_SA_EMAIL      : ${{ vars.GCP_SA_EMAIL }}"
           echo "GAR_REPOSITORY   : ${{ vars.GAR_REPOSITORY }}"
           echo "SERVICE_NAME     : ${{ vars.SERVICE_NAME }}"
           echo "VM_USER          : ${{ vars.VM_USER }}"
@@ -34,13 +36,15 @@ jobs:
           echo "HEALTH_CHECK_PORT: ${{ vars.HEALTH_CHECK_PORT }}"
           echo ""
           echo "=== Secrets (존재 여부만 확인) ==="
-          [ -n "$SECRET_VM_HOST"    ] && echo "VM_HOST     : ✅" || echo "VM_HOST     : ❌ 누락"
-          [ -n "$SECRET_VM_SSH_KEY" ] && echo "VM_SSH_KEY  : ✅" || echo "VM_SSH_KEY  : ❌ 누락"
+          [ -n "$SECRET_VM_HOST"            ] && echo "VM_HOST            : ✅" || echo "VM_HOST            : ❌ 누락"
+          [ -n "$SECRET_VM_SSH_KEY"         ] && echo "VM_SSH_KEY         : ✅" || echo "VM_SSH_KEY         : ❌ 누락"
+          [ -n "$SECRET_GCP_PROJECT_NUMBER" ] && echo "GCP_PROJECT_NUMBER : ✅" || echo "GCP_PROJECT_NUMBER : ❌ 누락"
           echo ""
 
           MISSING=()
           [ -z "${{ vars.GAR_LOCATION }}"      ] && MISSING+=("vars.GAR_LOCATION")
           [ -z "${{ vars.GCP_PROJECT_ID }}"    ] && MISSING+=("vars.GCP_PROJECT_ID")
+          [ -z "${{ vars.GCP_SA_EMAIL }}"       ] && MISSING+=("vars.GCP_SA_EMAIL")
           [ -z "${{ vars.GAR_REPOSITORY }}"    ] && MISSING+=("vars.GAR_REPOSITORY")
           [ -z "${{ vars.SERVICE_NAME }}"      ] && MISSING+=("vars.SERVICE_NAME")
           [ -z "${{ vars.VM_USER }}"           ] && MISSING+=("vars.VM_USER")
@@ -49,6 +53,7 @@ jobs:
           [ -z "${{ vars.HEALTH_CHECK_PORT }}" ] && MISSING+=("vars.HEALTH_CHECK_PORT")
           [ -z "$SECRET_VM_HOST"               ] && MISSING+=("secrets.VM_HOST")
           [ -z "$SECRET_VM_SSH_KEY"            ] && MISSING+=("secrets.VM_SSH_KEY")
+          [ -z "$SECRET_GCP_PROJECT_NUMBER"    ] && MISSING+=("secrets.GCP_PROJECT_NUMBER")
 
           if [ ${#MISSING[@]} -gt 0 ]; then
             echo "=== 누락된 변수 ==="
@@ -121,12 +126,15 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: projects/985172684764/locations/global/workloadIdentityPools/github-pool/providers/github-provider-v2
-          service_account: deployManager@melodic-crane-494802-u3.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider-v2
+          service_account: ${{ vars.GCP_SA_EMAIL }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
 
       - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ vars.GAR_LOCATION }}-docker.pkg.dev --quiet
+        run: |
+          gcloud auth configure-docker ${{ vars.GAR_LOCATION }}-docker.pkg.dev --quiet
+
 
       - name: Build and push image
         run: |
@@ -198,69 +206,44 @@ jobs:
               fi
             }
 
-            # =====================================================
-            # ↓↓↓ lecture-service 환경변수 ↓↓↓
-            # =====================================================
             upsert_env IMAGE_TAG "$NEW_TAG"
-            upsert_env EUREKA_CLIENT_SERVICEURL_DEFAULTZONE "http://${{ secrets.VM_HOST }}:9001/eureka/"
-
-            # DB
             upsert_env SPRING_DATASOURCE_URL "${{ secrets.DB_URL }}/${{ vars.DB_SCHEMA }}"
-            upsert_env DB_USERNAME "${{ secrets.DB_USERNAME }}"
-            upsert_env DB_PASSWORD "${{ secrets.DB_PASSWORD }}"
-
-            # Kafka
+            upsert_env EUREKA_CLIENT_SERVICEURL_DEFAULTZONE "http://${{ secrets.VM_HOST }}:9001/eureka/"
             upsert_env KAFKA_BOOTSTRAP_SERVERS "${{ secrets.KAFKA_1_INTERNAL_IP }}:9092,${{ secrets.KAFKA_2_INTERNAL_IP }}:9092,${{ secrets.KAFKA_3_INTERNAL_IP }}:9092"
-            upsert_env TRUST_STORE_PASSWORD "${{ secrets.TRUST_STORE_PASSWORD }}"
-
-            # Redis
-            upsert_env REDIS_SENTINEL_1 "${{ secrets.REDIS_1_INTERNAL_IP }}:26379"
-            upsert_env REDIS_SENTINEL_2 "${{ secrets.REDIS_2_INTERNAL_IP }}:26379"
-            upsert_env REDIS_SENTINEL_3 "${{ secrets.REDIS_3_INTERNAL_IP }}:26379"
-            upsert_env REDIS_PASSWORD "${{ secrets.REDIS_PASSWORD }}"
-
-            # Monitoring
             upsert_env MONITORING_HOST "${{ secrets.MONITORING_VM_HOST }}"
-            # =====================================================
 
             # Kafka SSL truststore 복원
             mkdir -p $APP_DIR/ssl
+
             TRUSTSTORE_B64="${{ secrets.TRUSTSTORE_JKS_B64 }}"
+            echo "[SSL] TRUSTSTORE_JKS_B64 secret 길이: ${#TRUSTSTORE_B64}"
             if [ -z "$TRUSTSTORE_B64" ]; then
               echo "[SSL] ❌ TRUSTSTORE_JKS_B64 secret이 비어있음"
               exit 1
             fi
+
             echo "$TRUSTSTORE_B64" | base64 -d > $APP_DIR/ssl/kafka.truststore.jks
-            FILE_SIZE=$(stat -c%s "$APP_DIR/ssl/kafka.truststore.jks")
-            echo "[SSL] ✅ 파일 생성 완료 (크기: ${FILE_SIZE} bytes)"
-            if [ "$FILE_SIZE" -eq 0 ]; then
-              echo "[SSL] ❌ 파일이 비어있음 — base64 디코딩 실패"
+
+            echo "[SSL] 파일 경로: $APP_DIR/ssl/kafka.truststore.jks"
+            if [ -f "$APP_DIR/ssl/kafka.truststore.jks" ]; then
+              FILE_SIZE=$(stat -c%s "$APP_DIR/ssl/kafka.truststore.jks")
+              echo "[SSL] ✅ 파일 존재 (크기: ${FILE_SIZE} bytes)"
+              if [ "$FILE_SIZE" -eq 0 ]; then
+                echo "[SSL] ❌ 파일이 비어있음 — base64 디코딩 실패"
+                exit 1
+              fi
+            else
+              echo "[SSL] ❌ 파일 생성 실패"
               exit 1
             fi
-            # [DEBUG-REMOVE] 디버깅 완료 후 제거 ↓↓↓
-            echo "[SSL] 호스트 경로: $(ls -lh $APP_DIR/ssl/kafka.truststore.jks)"
-            echo "[SSL] 파일 타입: $(file $APP_DIR/ssl/kafka.truststore.jks)"
-            # [DEBUG-REMOVE] 디버깅 완료 후 제거 ↑↑↑
+
+            echo "[SSL] ssl 디렉토리 내용:"
+            ls -lh $APP_DIR/ssl/
 
             # 새 이미지 pull & 재시작
             COMPOSE_FILE="${{ steps.vars.outputs.compose }}"
-            docker compose -f $COMPOSE_FILE pull $SERVICE
-            docker compose -f $COMPOSE_FILE up -d $SERVICE
-
-            # [DEBUG-REMOVE] 디버깅 완료 후 제거 ↓↓↓
-            # =====================================================
-            # 컨테이너 기동 후 디버그 정보 dump
-            # =====================================================
-            sleep 10
-            CONTAINER_NAME=$(docker compose -f $COMPOSE_FILE ps -q $SERVICE)
-            echo "[DEBUG] 컨테이너 ID: $CONTAINER_NAME"
-            echo "[DEBUG] 컨테이너 내부 /app/ssl/ 확인:"
-            docker exec "$CONTAINER_NAME" ls -lh /app/ssl/ 2>&1 || echo "[DEBUG] /app/ssl/ 확인 실패"
-            echo "[DEBUG] 컨테이너 내부 truststore 위치 검색:"
-            docker exec "$CONTAINER_NAME" find / -name 'kafka.truststore.jks' 2>/dev/null || echo "[DEBUG] find 실패"
-            echo "[DEBUG] 앱 시작 로그 (최근 100줄):"
-            docker logs "$CONTAINER_NAME" --tail 100 2>&1 || echo "[DEBUG] logs 실패"
-            # [DEBUG-REMOVE] 디버깅 완료 후 제거 ↑↑↑
+            docker compose --env-file $ENV_FILE -f $COMPOSE_FILE pull $SERVICE
+            docker compose --env-file $ENV_FILE -f $COMPOSE_FILE up -d $SERVICE
 
             # Health check (30초 간격, 최대 8회)
             echo "Health check 시작... (port: ${{ vars.HEALTH_CHECK_PORT }})"
@@ -272,18 +255,6 @@ jobs:
               fi
               echo "Health check 실패 ($i/8)"
             done
-
-            # [DEBUG-REMOVE] 디버깅 완료 후 제거 ↓↓↓
-            # =====================================================
-            # 헬스체크 실패 후 앱 로그 dump (디버깅용)
-            # =====================================================
-            echo "=================================================="
-            echo "[FATAL] 헬스체크 8회 모두 실패 — 앱 로그 dump"
-            echo "=================================================="
-            CONTAINER_NAME=$(docker compose -f $COMPOSE_FILE ps -q $SERVICE)
-            docker logs "$CONTAINER_NAME" --tail 300 2>&1 || echo "[FATAL] logs 실패"
-            echo "=================================================="
-            # [DEBUG-REMOVE] 디버깅 완료 후 제거 ↑↑↑
 
             # 롤백
             if [ -z "$PREV_TAG" ]; then

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,4 +8,8 @@ services:
       - "9005:9005"
     volumes:
       - ./ssl/kafka.truststore.jks:/app/ssl/kafka.truststore.jks:ro
+      - lecture-logs:/app/logs
     restart: on-failure:3
+
+volumes:
+  lecture-logs:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,9 +7,13 @@ services:
     ports:
       - "9005:9005"
     volumes:
-      - ./ssl/kafka.truststore.jks:/app/ssl/kafka.truststore.jks:ro
+      - /home/deploy/ssl/kafka.truststore.jks:/app/ssl/kafka.truststore.jks:ro
       - lecture-logs:/app/logs
     restart: on-failure:3
 
 volumes:
   lecture-logs:
+
+networks:
+  goggles-network:
+    external: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,28 @@ spring:
         service-id: config-server
       fail-fast: false
 
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${DB_USERNAME:goggles}
+    password: ${DB_PASSWORD:goggles}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 10
+      connection-timeout: 30000
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+        default_schema: lecture
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
 # Config Server를 Eureka로 찾으려면 Eureka 주소만 로컬에 있으면 됨
 eureka:
   client:


### PR DESCRIPTION
## 📌 관련 이슈
- close #44

## 💡 작업 내용
- Dockerfile 작성 (EXPOSE 9005)
- docker-compose 파일 작성
  - `docker-compose.dev.yml` (SPRING_PROFILES_ACTIVE: dev)
  - `docker-compose.prod.yml` (SPRING_PROFILES_ACTIVE: prod)
  - `docker-compose.yml` (fallback, 환경변수 명시)
- 컨테이너 포트 9005, 외부 노출 포트 9005로 통일 (Spring `server.port: 9005`)
- `.gitignore`에 `*.jks`, `.env*` 등 보안 파일 패턴 추가
- `dev` 브랜치 push → dev 환경 자동 배포 / `main` 브랜치 push → prod 환경 자동 배포
- mentoring-service의 deploy.yml을 베이스로 하고, lecture-service가 사용하는 환경변수를 `upsert_env`에 추가
  - DB (`SPRING_DATASOURCE_URL`, `DB_USERNAME`, `DB_PASSWORD`)
  - Kafka (`KAFKA_BOOTSTRAP_SERVERS`, `TRUST_STORE_PASSWORD`)
  - Redis Sentinel (`REDIS_SENTINEL_1~3`, `REDIS_PASSWORD`)
  - Eureka, Monitoring
- GitHub Repository Variables 등록 (`SERVICE_NAME`, `HEALTH_CHECK_PORT`, `DB_SCHEMA`)

## 🔍 변경 이유
- 로컬 docker-compose만으로는 MSA 구성 검증이 불가능 (서비스 디스커버리, 부하 테스트, 모니터링)
- 후속 기능 개발 시 빠른 피드백 루프 확보를 위해 자동 배포 우선 구축
- mentoring-service의 검증된 배포 패턴을 그대로 활용하여 일관성 확보

## 📝 리뷰 포인트 (선택)
- `docker-compose.yml` (fallback)의 환경변수 이름이 application.yaml과 일치하는지
- `.gitignore`의 보안 파일 패턴 (`*.jks`, `.env*` 등) 충분 여부

## 🧠 기타 참고 사항
- Redis 인프라는 팀 공통 인프라 사용 (Organization Secrets `REDIS_X_INTERNAL_IP`, `REDIS_PASSWORD` 활용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 커밋 시 자동 빌드·테스트·이미지 생성·레지스트리 푸시 및 원격 VM 배포, 서비스 재시작과 헬스체크 기반 자동 롤백
  * 개발/프로덕션용 경량 컨테이너 이미지 및 환경별 compose 구성 추가

* **보안**
  * 환경변수 파일 및 SSL 인증서/키 파일을 명시적으로 무시하도록 Git 무시 규칙 강화
  * 배포 시 신뢰 저장소 복원 및 암호 안전 처리 추가

* **테스트/구성**
  * 테스트 프로파일과 인메모리 DB·로컬 메시징 설정 추가, 클라우드 구성 비활성화 및 빌드 설정 인증 흐름 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/9oogle/lecture-service/pull/51)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->